### PR TITLE
Fix typo in MiddlewareBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ abstract class BaseCounter extends BuiltReducer<BaseCounter, BaseCounterBuilder>
 ### Writing middleware
 ```dart
  // Define specific actions to be handled by this middleware
- // A middlware can also listen to and perform side effects on any actions defined elsewhere
+ // A middleware can also listen to and perform side effects on any actions defined elsewhere
  abstract class DoubleAction extends ReduxActions {
   ActionDispatcher<int> increment;
 
@@ -174,9 +174,9 @@ abstract class BaseCounter extends BuiltReducer<BaseCounter, BaseCounterBuilder>
  // just like ReducerBuilder it is strongly recommended as it gives you static type checking to make sure
  // the payload for action name provided is the same as the expected payload
  // for the action provided to your reducer. It will also call next(action) for you
- // if an action not handled by this middlware is received. Calling .build() returns the
+ // if an action not handled by this middleware is received. Calling .build() returns the
  // middleware function that can be passed to your store at instantiation.
- var doubleMiddleware =  (new MiddlwareBuilder<Counter, CounterBuilder, CounterActions>()
+ var doubleMiddleware =  (new MiddlewareBuilder<Counter, CounterBuilder, CounterActions>()
       ..add<int>(DoubleActionNames.increment, _doubleIt)).build();
 
 _doubleIt(MiddlewareApi<Counter, CounterBuilder, CounterActions> api, ActionHandler next, Action<int> action) {
@@ -184,7 +184,7 @@ _doubleIt(MiddlewareApi<Counter, CounterBuilder, CounterActions> api, ActionHand
 }
 ```
 
-You will notice that MiddlwareBuilder's generics are Counter and CounterActions.
+You will notice that MiddlewareBuilder's generics are Counter and CounterActions.
 These are the same types as the defaultState and actions classes passed when
 the store was instantiated. In order for DoubleActions to be handled by redux
 you must add it to definition of CounterActions like so

--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -6,7 +6,7 @@ import 'store.dart';
 import 'typedefs.dart';
 
 /// [MiddlewareApi] put in scope to your [Middleware] function by redux.
-/// When using [MiddlwareBuilder] (recommended) [MiddlewareApi] is passed to your [MiddlewareHandler]
+/// When using [MiddlewareBuilder] (recommended) [MiddlewareApi] is passed to your [MiddlewareHandler]
 class MiddlewareApi<State extends BuiltReducer<State, StateBuilder>,
     StateBuilder extends Builder<State, StateBuilder>, Actions extends ReduxActions> {
   Store<State, StateBuilder, Actions> _store;
@@ -19,11 +19,11 @@ class MiddlewareApi<State extends BuiltReducer<State, StateBuilder>,
   Actions get actions => _store.actions;
 }
 
-/// [MiddlwareBuilder] allows you to build a reducer that handles many different actions
+/// [MiddlewareBuilder] allows you to build a reducer that handles many different actions
 /// with many different payload types, while maintaining type safety.
 /// Each [MiddlewareHandler] added with add<T> must take a state of type State, an Action of type
 /// Action<T>, and a builder of type StateBuilder
-class MiddlwareBuilder<State extends BuiltReducer<State, StateBuilder>,
+class MiddlewareBuilder<State extends BuiltReducer<State, StateBuilder>,
     StateBuilder extends Builder<State, StateBuilder>, Actions extends ReduxActions> {
   var _map = new Map<String, MiddlewareHandler<State, StateBuilder, Actions>>();
 
@@ -31,7 +31,7 @@ class MiddlwareBuilder<State extends BuiltReducer<State, StateBuilder>,
     _map[aMgr.name] = handler;
   }
 
-  /// build returns a [Middlware] function that handles all actions added with [add]
+  /// build returns a [Middleware] function that handles all actions added with [add]
   Middleware<State, StateBuilder, Actions> build() =>
       (MiddlewareApi<State, StateBuilder, Actions> api) => (ActionHandler next) => (Action action) {
             var handler = _map[action.name];
@@ -45,7 +45,7 @@ class MiddlwareBuilder<State extends BuiltReducer<State, StateBuilder>,
 }
 
 /// [MiddlewareHandler] is a function that handles an action in a middleware. Its is only for
-/// use with [MiddlwareBuilder]. If you are not using [MiddlwareBuilder] middleware must be
+/// use with [MiddlewareBuilder]. If you are not using [MiddlewareBuilder] middleware must be
 /// decalred as a [Middleware] function.
 typedef void MiddlewareHandler<
     State extends BuiltReducer<State, StateBuilder>,

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -15,7 +15,7 @@ typedef void Reducer<
 /// [ActionHandler] handles an action, this will contain the actual middleware logic
 typedef void ActionHandler(Action a);
 
-/// [NextActionHandler] takes the next [ActionHandler] in the middlware chain and returns
+/// [NextActionHandler] takes the next [ActionHandler] in the middleware chain and returns
 /// an [ActionHandler] for the middleware
 typedef ActionHandler NextActionHandler(ActionHandler next);
 

--- a/test/unit/redux_test.dart
+++ b/test/unit/redux_test.dart
@@ -13,15 +13,15 @@ main() {
       var actions = new BaseCounterActions();
       var defaultValue = new BaseCounter();
 
-      var middlware = new List<Middleware>();
+      var middleware = new List<Middleware>();
       for (int i = 0; i < numMiddleware; i++) {
-        middlware.add(counterMiddleware);
+        middleware.add(counterMiddleware);
       }
 
       store = new Store(
         defaultValue,
         actions,
-        middleware: middlware,
+        middleware: middleware,
       );
     }
 
@@ -64,7 +64,7 @@ main() {
       expect(stateChange.next.count, 3);
     });
 
-    test('2 middlwares doubles count twice and updates state', () async {
+    test('2 middlewares doubles count twice and updates state', () async {
       setup(numMiddleware: 2);
       Completer onStateChangeCompleter =
           new Completer<StoreChange<BaseCounter, BaseCounterBuilder, BaseCounterActions>>();

--- a/test/unit/test_counter.dart
+++ b/test/unit/test_counter.dart
@@ -91,7 +91,7 @@ abstract class MiddlewareActions extends ReduxActions {
   factory MiddlewareActions() => new _$MiddlewareActions();
 }
 
-var counterMiddleware = (new MiddlwareBuilder<BaseCounter, BaseCounterBuilder, BaseCounterActions>()
+var counterMiddleware = (new MiddlewareBuilder<BaseCounter, BaseCounterBuilder, BaseCounterActions>()
       ..add<int>(MiddlewareActionsNames.increment, _doubleIt))
     .build();
 


### PR DESCRIPTION
This fixes a typo in the MiddlewareBuilder class name and a few others with the same typo.