### PR TITLE
support `Null` and typedefs as generic type parameters for actions

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -108,8 +108,16 @@ class _\$${element.name} extends ${element.name}{
   return '$initializerCode\n\n$nameCode';
 }
 
-String _getActionDispatcherGenericType(FieldElement e) =>
-    (e.type as InterfaceType).typeArguments.first.name;
+String _getActionDispatcherGenericType(FieldElement e) {
+  var typeArgument =
+      (e.type as InterfaceType).typeArguments.first as ParameterizedType;
+  // generic type has generic type parameters?
+  if (typeArgument.typeArguments.isEmpty ||
+      typeArgument.typeArguments.every((ta) => ta.name == 'dynamic')) {
+    return typeArgument.name;
+  }
+  return '${typeArgument.name}<${typeArgument.typeArguments.join(',')}>';
+}
 
 String _generateReducer(ClassElement element) {
   const reduceChildrenMatcher = '**reduceChildrenMatcher**';

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -44,25 +45,35 @@ bool _isGeneratedDispatcherFinal(String dispatcherCode) =>
     dispatcherCode.startsWith('\nfinal') || dispatcherCode.startsWith('final');
 
 String _generateActions(ClassElement element) {
-  var initializerCode =
-      "class _\$${element.name} extends ${element.name}{\nfactory _\$${element.name}() => new _\$${element.name}._();\n_\$${element.name}._() : super._();\nsyncWithStore(dispatcher);\n}";
-  var nameCode = "class ${element.name}Names {\n\n}";
-  var syncWithStoreCode = 'syncWithStore(dispatcher) {\n\n}';
+  var defaultFunctionDeclaration =
+      '@override void syncWithStore(Dispatcher dispatcher)';
+  var initializerCode = '''
+class _\$${element.name} extends ${element.name}{
+  factory _\$${element.name}() => new _\$${element.name}._();
+  
+  _\$${element.name}._() : super._();
+  
+  $defaultFunctionDeclaration;
+}''';
+
+  var nameCode = 'class ${element.name}Names {\n}';
+  var syncWithStoreCode = '$defaultFunctionDeclaration{\n}';
   for (var e in element.fields) {
     var fieldName = e.name;
     var ele = e.type.element;
     var typeName = ele.name;
 
     if (_isActionDispatcher(ele)) {
+      var genericType = _getActionDispatcherGenericType(e);
       // generate the action name
       nameCode = _appendCode(
         nameCode,
-        'static final ActionName<${_getActionDispatcherGenericType(e)}> $fieldName = new ActionName<${_getActionDispatcherGenericType(e)}>(\'${element.name}-$fieldName\');\n',
+        'static final ActionName<${genericType}> $fieldName = new ActionName<${genericType}>(\'${element.name}-$fieldName\');\n',
       );
 
       // generate the dispatcher
       var actionDispatcher =
-          '\n${e.toString()} = new ActionDispatcher<${_getActionDispatcherGenericType(e)}>(\'${element.name}-$fieldName\');\n';
+          '\n${e.type.name}<${genericType}> ${e.name} = new ActionDispatcher<${genericType}>(\'${element.name}-$fieldName\');\n';
 
       // if it was not declared final make it final
       if (!_isGeneratedDispatcherFinal(actionDispatcher))
@@ -81,7 +92,7 @@ String _generateActions(ClassElement element) {
       // generate the instantiation
       initializerCode = _appendCode(
         initializerCode,
-        'final ${e.toString()} = new $typeName();',
+        'final $e = new $typeName();',
       );
 
       // append the sync function for this set of actions
@@ -93,37 +104,36 @@ String _generateActions(ClassElement element) {
   }
 
   initializerCode = initializerCode.replaceFirst(
-      'syncWithStore(dispatcher);', syncWithStoreCode);
+      '$defaultFunctionDeclaration;', syncWithStoreCode);
   return '$initializerCode\n\n$nameCode';
 }
 
-// TODO: find a better way
 String _getActionDispatcherGenericType(FieldElement e) =>
-    e.toString().substring(
-          e.toString().indexOf('<') + 1,
-          e.toString().lastIndexOf('>'),
-        );
+    (e.type as InterfaceType).typeArguments.first.name;
 
 String _generateReducer(ClassElement element) {
   const reduceChildrenMatcher = '**reduceChildrenMatcher**';
   var builtName = element.name;
   var builderName = '${element.name}Builder';
-  var nameCode =
-      """abstract class ${builtName}Reducer implements BuiltReducer<$builtName, $builderName> {
-        Map<String, Reducer<dynamic, $builtName, $builderName>>
-            get reducer => null;
+  var nameCode = '''
+abstract class ${builtName}Reducer implements BuiltReducer<$builtName, $builderName> {
+  Map<String, Reducer<dynamic, $builtName, $builderName>>
+      get reducer => null;
 
-        void reduce(
-            $builtName state, Action<dynamic> a, $builderName builder) {
-          if (reducer != null) {
-            var handler = reducer[a.name];
-            if (handler != null) handler(state, a, builder);
-          }
-          reduceChildren(state, a, builder);
-        }
+  void reduce(
+      $builtName state, Action<dynamic> a, $builderName builder) {
+    if (reducer != null) {
+      final handler = reducer[a.name];
+      if (handler != null) handler(state, a, builder);
+    }
+    reduceChildren(state, a, builder);
+  }
 
-        reduceChildren($builtName state, Action<dynamic> a, $builderName builder) { $reduceChildrenMatcher }
-      }""";
+  void reduceChildren($builtName state, Action<dynamic> a, $builderName builder) { 
+    $reduceChildrenMatcher 
+  }
+}
+''';
 
   var reduceChildrenContent = '';
   for (var e in element.fields) {

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -101,7 +101,7 @@ class ActionDispatcher<P> {
 /// }
 /// ```
 abstract class ReduxActions {
-  void syncWithStore(dispatcher);
+  void syncWithStore(Dispatcher dispatcher);
 }
 
 /// [ActionName] is an object that simply contains the action name but is typed with a generic that

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_redux
-version: 5.0.0
+version: 5.1.0
 description:
   A state management library written in dart that enforces immutability
 authors:

--- a/test/unit/redux_test.dart
+++ b/test/unit/redux_test.dart
@@ -13,7 +13,10 @@ main() {
       var actions = new BaseCounterActions();
       var defaultValue = new BaseCounter();
 
-      var middleware = new List<Middleware>();
+      var middleware =
+          <Middleware<BaseCounter, BaseCounterBuilder, BaseCounterActions>>[
+        fooTypedefMiddleware
+      ];
       for (int i = 0; i < numMiddleware; i++) {
         middleware.add(counterMiddleware);
       }
@@ -164,6 +167,24 @@ main() {
       store.actions.increment(4);
       await onStreamError.future;
       sub.cancel();
+    });
+
+    test('ActionDispatcher<Null>', () async {
+      setup();
+      store.actions.incrementOne(null);
+      var stateChange = await store.stream.first;
+      expect(stateChange.prev.count, 1);
+      expect(stateChange.next.count, 2);
+    });
+
+    test('ActionDispatcher<SomeTypeDef>', () async {
+      setup();
+      store.actions.foo((MiddlewareApi api) {
+        (api.actions as BaseCounterActions).incrementOne(null);
+      });
+      var stateChange = await store.stream.first;
+      expect(stateChange.prev.count, 1);
+      expect(stateChange.next.count, 2);
     });
   });
 }

--- a/test/unit/redux_test.dart
+++ b/test/unit/redux_test.dart
@@ -186,5 +186,20 @@ main() {
       expect(stateChange.prev.count, 1);
       expect(stateChange.next.count, 2);
     });
+
+    test('payload with generic type', () async {
+      setup();
+      store.actions.genericAction1(<int>[1, 2, 3]);
+      var stateChange = await store.stream.first;
+      expect(stateChange.prev.count, 1);
+      expect(stateChange.next.count, 7);
+
+      store.actions.genericAction2(<String, List<int>>{
+        'add': [1, 2, 3]
+      });
+      stateChange = await store.stream.first;
+      expect(stateChange.prev.count, 7);
+      expect(stateChange.next.count, 13);
+    });
   });
 }

--- a/test/unit/test_counter.dart
+++ b/test/unit/test_counter.dart
@@ -19,6 +19,8 @@ abstract class BaseCounterActions extends ReduxActions {
   ActionDispatcher<int> decrement;
   ActionDispatcher<Null> incrementOne;
   ActionDispatcher<FooTypedef> foo;
+  ActionDispatcher<List<int>> genericAction1;
+  ActionDispatcher<Map<String, List<int>>> genericAction2;
 
   NestedCounterActions nestedCounterActions;
   MiddlewareActions middlewareActions;
@@ -39,10 +41,24 @@ _baseIncrementOne(
         BaseCounter state, Action<Null> action, BaseCounterBuilder builder) =>
     builder..count = state.count + 1;
 
+_baseGenericAction1(BaseCounter state, Action<List<int>> action,
+        BaseCounterBuilder builder) =>
+    builder
+      ..count = state.count +
+          action.payload.reduce((value, element) => value + element);
+
+_baseGenericAction2(BaseCounter state, Action<Map<String, List<int>>> action,
+        BaseCounterBuilder builder) =>
+    builder
+      ..count = state.count +
+          action.payload['add'].reduce((value, element) => value + element);
+
 final _baseReducer = (new ReducerBuilder<BaseCounter, BaseCounterBuilder>()
       ..add(BaseCounterActionsNames.increment, _baseIncrement)
       ..add(BaseCounterActionsNames.decrement, _baseDecrement)
-      ..add(BaseCounterActionsNames.incrementOne, _baseIncrementOne))
+      ..add(BaseCounterActionsNames.incrementOne, _baseIncrementOne)
+      ..add(BaseCounterActionsNames.genericAction1, _baseGenericAction1)
+      ..add(BaseCounterActionsNames.genericAction2, _baseGenericAction2))
     .build();
 
 // Built Reducer

--- a/test/unit/test_counter.dart
+++ b/test/unit/test_counter.dart
@@ -8,11 +8,17 @@ import 'package:built_collection/built_collection.dart';
 
 part 'test_counter.g.dart';
 
+/// Used to test code generation when the generic type of an action is a
+/// `typedef`
+typedef dynamic FooTypedef(MiddlewareApi api);
+
 // BaseCounter
 
 abstract class BaseCounterActions extends ReduxActions {
   ActionDispatcher<int> increment;
   ActionDispatcher<int> decrement;
+  ActionDispatcher<Null> incrementOne;
+  ActionDispatcher<FooTypedef> foo;
 
   NestedCounterActions nestedCounterActions;
   MiddlewareActions middlewareActions;
@@ -29,9 +35,14 @@ _baseDecrement(
         BaseCounter state, Action<int> action, BaseCounterBuilder builder) =>
     builder..count = state.count - action.payload;
 
+_baseIncrementOne(
+        BaseCounter state, Action<Null> action, BaseCounterBuilder builder) =>
+    builder..count = state.count + 1;
+
 final _baseReducer = (new ReducerBuilder<BaseCounter, BaseCounterBuilder>()
       ..add(BaseCounterActionsNames.increment, _baseIncrement)
-      ..add(BaseCounterActionsNames.decrement, _baseDecrement))
+      ..add(BaseCounterActionsNames.decrement, _baseDecrement)
+      ..add(BaseCounterActionsNames.incrementOne, _baseIncrementOne))
     .build();
 
 // Built Reducer
@@ -61,6 +72,8 @@ abstract class BaseCounter extends Object
 abstract class NestedCounterActions extends ReduxActions {
   ActionDispatcher<int> increment;
   ActionDispatcher<int> decrement;
+  ActionDispatcher<Null> incrementOne;
+  ActionDispatcher<FooTypedef> fooTypedef;
 
   NestedCounterActions._();
   factory NestedCounterActions() => new _$NestedCounterActions();
@@ -74,10 +87,15 @@ _nestedDecrement(NestedCounter state, Action<int> action,
         NestedCounterBuilder builder) =>
     builder..count = state.count - action.payload;
 
+_nestedIncrementOne(NestedCounter state, Action<Null> action,
+        NestedCounterBuilder builder) =>
+    builder..count = state.count + 1;
+
 final _nestedReducer =
     (new ReducerBuilder<NestedCounter, NestedCounterBuilder>()
           ..add(NestedCounterActionsNames.increment, _nestedIncrement)
-          ..add(NestedCounterActionsNames.decrement, _nestedDecrement))
+          ..add(NestedCounterActionsNames.decrement, _nestedDecrement)
+          ..add(NestedCounterActionsNames.incrementOne, _nestedIncrementOne))
         .build();
 
 abstract class NestedCounter extends Object
@@ -113,6 +131,19 @@ _doubleIt(
   api.actions.increment(api.state.count * 2);
   next(action);
 }
+
+// typedef
+
+NextActionHandler fooTypedefMiddleware(
+        MiddlewareApi<BaseCounter, BaseCounterBuilder, BaseCounterActions>
+            api) =>
+    (ActionHandler next) => (Action a) {
+          if (a.payload is FooTypedef) {
+            a.payload(api);
+          }
+
+          next(a);
+        };
 
 // Change handler
 

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -194,22 +194,37 @@ class NestedCounterBuilder
 class _$BaseCounterActions extends BaseCounterActions {
   final MiddlewareActions middlewareActions = new MiddlewareActions();
   final NestedCounterActions nestedCounterActions = new NestedCounterActions();
+  final ActionDispatcher<FooTypedef> foo =
+      new ActionDispatcher<FooTypedef>('BaseCounterActions-foo');
+
+  final ActionDispatcher<Null> incrementOne =
+      new ActionDispatcher<Null>('BaseCounterActions-incrementOne');
+
   final ActionDispatcher<int> decrement =
       new ActionDispatcher<int>('BaseCounterActions-decrement');
 
   final ActionDispatcher<int> increment =
       new ActionDispatcher<int>('BaseCounterActions-increment');
   factory _$BaseCounterActions() => new _$BaseCounterActions._();
+
   _$BaseCounterActions._() : super._();
-  syncWithStore(dispatcher) {
+
+  @override
+  void syncWithStore(Dispatcher dispatcher) {
     middlewareActions.syncWithStore(dispatcher);
     nestedCounterActions.syncWithStore(dispatcher);
+    foo.syncWithStore(dispatcher);
+    incrementOne.syncWithStore(dispatcher);
     decrement.syncWithStore(dispatcher);
     increment.syncWithStore(dispatcher);
   }
 }
 
 class BaseCounterActionsNames {
+  static final ActionName<FooTypedef> foo =
+      new ActionName<FooTypedef>('BaseCounterActions-foo');
+  static final ActionName<Null> incrementOne =
+      new ActionName<Null>('BaseCounterActions-incrementOne');
   static final ActionName<int> decrement =
       new ActionName<int>('BaseCounterActions-decrement');
   static final ActionName<int> increment =
@@ -224,33 +239,48 @@ abstract class BaseCounterReducer
   void reduce(
       BaseCounter state, Action<dynamic> a, BaseCounterBuilder builder) {
     if (reducer != null) {
-      var handler = reducer[a.name];
+      final handler = reducer[a.name];
       if (handler != null) handler(state, a, builder);
     }
     reduceChildren(state, a, builder);
   }
 
-  reduceChildren(
+  void reduceChildren(
       BaseCounter state, Action<dynamic> a, BaseCounterBuilder builder) {
     state.nestedCounter.reduce(state.nestedCounter, a, builder.nestedCounter);
   }
 }
 
 class _$NestedCounterActions extends NestedCounterActions {
+  final ActionDispatcher<FooTypedef> fooTypedef =
+      new ActionDispatcher<FooTypedef>('NestedCounterActions-fooTypedef');
+
+  final ActionDispatcher<Null> incrementOne =
+      new ActionDispatcher<Null>('NestedCounterActions-incrementOne');
+
   final ActionDispatcher<int> decrement =
       new ActionDispatcher<int>('NestedCounterActions-decrement');
 
   final ActionDispatcher<int> increment =
       new ActionDispatcher<int>('NestedCounterActions-increment');
   factory _$NestedCounterActions() => new _$NestedCounterActions._();
+
   _$NestedCounterActions._() : super._();
-  syncWithStore(dispatcher) {
+
+  @override
+  void syncWithStore(Dispatcher dispatcher) {
+    fooTypedef.syncWithStore(dispatcher);
+    incrementOne.syncWithStore(dispatcher);
     decrement.syncWithStore(dispatcher);
     increment.syncWithStore(dispatcher);
   }
 }
 
 class NestedCounterActionsNames {
+  static final ActionName<FooTypedef> fooTypedef =
+      new ActionName<FooTypedef>('NestedCounterActions-fooTypedef');
+  static final ActionName<Null> incrementOne =
+      new ActionName<Null>('NestedCounterActions-incrementOne');
   static final ActionName<int> decrement =
       new ActionName<int>('NestedCounterActions-decrement');
   static final ActionName<int> increment =
@@ -265,13 +295,13 @@ abstract class NestedCounterReducer
   void reduce(
       NestedCounter state, Action<dynamic> a, NestedCounterBuilder builder) {
     if (reducer != null) {
-      var handler = reducer[a.name];
+      final handler = reducer[a.name];
       if (handler != null) handler(state, a, builder);
     }
     reduceChildren(state, a, builder);
   }
 
-  reduceChildren(
+  void reduceChildren(
       NestedCounter state, Action<dynamic> a, NestedCounterBuilder builder) {}
 }
 
@@ -279,8 +309,11 @@ class _$MiddlewareActions extends MiddlewareActions {
   final ActionDispatcher<int> increment =
       new ActionDispatcher<int>('MiddlewareActions-increment');
   factory _$MiddlewareActions() => new _$MiddlewareActions._();
+
   _$MiddlewareActions._() : super._();
-  syncWithStore(dispatcher) {
+
+  @override
+  void syncWithStore(Dispatcher dispatcher) {
     increment.syncWithStore(dispatcher);
   }
 }

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -194,6 +194,13 @@ class NestedCounterBuilder
 class _$BaseCounterActions extends BaseCounterActions {
   final MiddlewareActions middlewareActions = new MiddlewareActions();
   final NestedCounterActions nestedCounterActions = new NestedCounterActions();
+  final ActionDispatcher<Map<String, List<int>>> genericAction2 =
+      new ActionDispatcher<Map<String, List<int>>>(
+          'BaseCounterActions-genericAction2');
+
+  final ActionDispatcher<List<int>> genericAction1 =
+      new ActionDispatcher<List<int>>('BaseCounterActions-genericAction1');
+
   final ActionDispatcher<FooTypedef> foo =
       new ActionDispatcher<FooTypedef>('BaseCounterActions-foo');
 
@@ -213,6 +220,8 @@ class _$BaseCounterActions extends BaseCounterActions {
   void syncWithStore(Dispatcher dispatcher) {
     middlewareActions.syncWithStore(dispatcher);
     nestedCounterActions.syncWithStore(dispatcher);
+    genericAction2.syncWithStore(dispatcher);
+    genericAction1.syncWithStore(dispatcher);
     foo.syncWithStore(dispatcher);
     incrementOne.syncWithStore(dispatcher);
     decrement.syncWithStore(dispatcher);
@@ -221,6 +230,11 @@ class _$BaseCounterActions extends BaseCounterActions {
 }
 
 class BaseCounterActionsNames {
+  static final ActionName<Map<String, List<int>>> genericAction2 =
+      new ActionName<Map<String, List<int>>>(
+          'BaseCounterActions-genericAction2');
+  static final ActionName<List<int>> genericAction1 =
+      new ActionName<List<int>>('BaseCounterActions-genericAction1');
   static final ActionName<FooTypedef> foo =
       new ActionName<FooTypedef>('BaseCounterActions-foo');
   static final ActionName<Null> incrementOne =


### PR DESCRIPTION
some generator refactoring
  - to avoid linter warnings
    (missing type parameters, final instead of var, ...)
  - shorten lines, unify quotes