### PR TITLE
Fix thunk and repatch generic generation

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -39,9 +39,9 @@ String _generateActions(ClassElement element) {
   var initializerCode = '''
 class _\$${element.name} extends ${element.name}{
   factory _\$${element.name}() => new _\$${element.name}._();
-  
+
   _\$${element.name}._() : super._();
-  
+
   $defaultFunctionDeclaration;
 }''';
 
@@ -126,7 +126,11 @@ String _getActionDispatcherGenericType(FieldElement e) {
         b.name.startsWith('Built') &&
         i != boundParams.length - 1) {
       final next = boundParams.elementAt(i + 1);
-      if (next != null && next.name.startsWith('Builder')) {
+      if (next != null &&
+          next.name.startsWith('Builder') &&
+          typeArguments.elementAt(i + 1) == 'dynamic') {
+        log.info(
+            "replacing unresolved builder name ${typeArguments.elementAt(i)}Builder");
         // if it is a builder replace typeArguments at this location as
         // the Built's name + Builder
         typeArguments.replaceRange(

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -105,7 +105,40 @@ String _getActionDispatcherGenericType(FieldElement e) {
       typeArgument.typeArguments.every((ta) => ta.name == 'dynamic')) {
     return typeArgument.name;
   }
-  return '${typeArgument.name}<${typeArgument.typeArguments.join(',')}>';
+
+  final typeArguments =
+      typeArgument.typeArguments.map((ta) => ta.toString()).toList();
+
+  // hack for thunks/repatches or any other type argument list where
+  // any given argument is a Built and the proceding is a Builder
+  // and the builder is dynamic in the typeArguments list becauses it is
+  // yet to be generated. This is complex and a bit awkward but
+  // it is written this way to be very careful not to make any unintended
+  // changes the the typeArguments list.
+  final boundParams = typeArgument.typeParameters.map((e) => e.bound);
+  for (int i = 0; i < boundParams.length; i++) {
+    // get the bound param at this spot
+    final b = boundParams.elementAt(i);
+
+    // if it is a Built and there is another argument after it
+    // check if it is supposed to be a Builder
+    if (b != null &&
+        b.name.startsWith('Built') &&
+        i != boundParams.length - 1) {
+      final next = boundParams.elementAt(i + 1);
+      if (next != null && next.name.startsWith('Builder')) {
+        // if it is a builder replace typeArguments at this location as
+        // the Built's name + Builder
+        typeArguments.replaceRange(
+          i + 1,
+          i + 2,
+          ['${typeArguments.elementAt(i)}Builder'],
+        );
+      }
+    }
+  }
+
+  return '${typeArgument.name}<${typeArguments.join(',')}>';
 }
 
 String _appendCode(String before, String newCode) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_redux
-version: 6.1.0
+version: 6.1.1
 description:
   A state management library written in dart that enforces immutability
 authors:

--- a/test/unit/redux_test.dart
+++ b/test/unit/redux_test.dart
@@ -208,8 +208,10 @@ main() {
 
     test('ActionDispatcher<SomeTypeDef>', () async {
       setup();
-      store.actions.foo((MiddlewareApi api) {
-        (api.actions as BaseCounterActions).incrementOne();
+      store.actions.thunkDispatcher(
+          (MiddlewareApi<BaseCounter, BaseCounterBuilder, BaseCounterActions>
+              api) {
+        api.actions.incrementOne();
       });
       var stateChange = await store.stream.first;
       expect(stateChange.prev.count, 1);

--- a/test/unit/test_counter.dart
+++ b/test/unit/test_counter.dart
@@ -10,7 +10,8 @@ part 'test_counter.g.dart';
 
 /// Used to test code generation when the generic type of an action is a
 /// `typedef`
-typedef dynamic FooTypedef(MiddlewareApi api);
+typedef dynamic ThunkTypedef<V extends Built<V, B>, B extends Builder<V, B>,
+    A extends ReduxActions>(MiddlewareApi<V, B, A> api);
 
 // BaseCounter
 
@@ -18,7 +19,9 @@ abstract class BaseCounterActions extends ReduxActions {
   ActionDispatcher<int> increment;
   ActionDispatcher<int> decrement;
   ActionDispatcher<Null> incrementOne;
-  ActionDispatcher<FooTypedef> foo;
+  ActionDispatcher<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder, BaseCounterActions>>
+      thunkDispatcher;
   ActionDispatcher<List<int>> genericAction1;
   ActionDispatcher<Map<String, List<int>>> genericAction2;
   ActionDispatcher<int> appendToNestedList;
@@ -86,7 +89,9 @@ abstract class NestedCounterActions extends ReduxActions {
   ActionDispatcher<int> increment;
   ActionDispatcher<int> decrement;
   ActionDispatcher<Null> incrementOne;
-  ActionDispatcher<FooTypedef> fooTypedef;
+  ActionDispatcher<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder, BaseCounterActions>>
+      thunkDispatcher;
 
   NestedCounterActions._();
   factory NestedCounterActions() => new _$NestedCounterActions();
@@ -148,7 +153,7 @@ NextActionHandler fooTypedefMiddleware(
         MiddlewareApi<BaseCounter, BaseCounterBuilder, BaseCounterActions>
             api) =>
     (ActionHandler next) => (Action a) {
-          if (a.payload is FooTypedef) {
+          if (a.payload is ThunkTypedef) {
             a.payload(api);
           }
 

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -210,8 +210,11 @@ class _$BaseCounterActions extends BaseCounterActions {
   final ActionDispatcher<List<int>> genericAction1 =
       new ActionDispatcher<List<int>>('BaseCounterActions-genericAction1');
 
-  final ActionDispatcher<FooTypedef> foo =
-      new ActionDispatcher<FooTypedef>('BaseCounterActions-foo');
+  final ActionDispatcher<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder, BaseCounterActions>>
+      thunkDispatcher = new ActionDispatcher<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder,
+              BaseCounterActions>>('BaseCounterActions-thunkDispatcher');
 
   final ActionDispatcher<Null> incrementOne =
       new ActionDispatcher<Null>('BaseCounterActions-incrementOne');
@@ -232,7 +235,7 @@ class _$BaseCounterActions extends BaseCounterActions {
     appendToNestedList.setDispatcher(dispatcher);
     genericAction2.setDispatcher(dispatcher);
     genericAction1.setDispatcher(dispatcher);
-    foo.setDispatcher(dispatcher);
+    thunkDispatcher.setDispatcher(dispatcher);
     incrementOne.setDispatcher(dispatcher);
     decrement.setDispatcher(dispatcher);
     increment.setDispatcher(dispatcher);
@@ -247,8 +250,11 @@ class BaseCounterActionsNames {
           'BaseCounterActions-genericAction2');
   static final ActionName<List<int>> genericAction1 =
       new ActionName<List<int>>('BaseCounterActions-genericAction1');
-  static final ActionName<FooTypedef> foo =
-      new ActionName<FooTypedef>('BaseCounterActions-foo');
+  static final ActionName<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder, BaseCounterActions>>
+      thunkDispatcher = new ActionName<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder,
+              BaseCounterActions>>('BaseCounterActions-thunkDispatcher');
   static final ActionName<Null> incrementOne =
       new ActionName<Null>('BaseCounterActions-incrementOne');
   static final ActionName<int> decrement =
@@ -258,8 +264,11 @@ class BaseCounterActionsNames {
 }
 
 class _$NestedCounterActions extends NestedCounterActions {
-  final ActionDispatcher<FooTypedef> fooTypedef =
-      new ActionDispatcher<FooTypedef>('NestedCounterActions-fooTypedef');
+  final ActionDispatcher<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder, BaseCounterActions>>
+      thunkDispatcher = new ActionDispatcher<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder,
+              BaseCounterActions>>('NestedCounterActions-thunkDispatcher');
 
   final ActionDispatcher<Null> incrementOne =
       new ActionDispatcher<Null>('NestedCounterActions-incrementOne');
@@ -275,7 +284,7 @@ class _$NestedCounterActions extends NestedCounterActions {
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
-    fooTypedef.setDispatcher(dispatcher);
+    thunkDispatcher.setDispatcher(dispatcher);
     incrementOne.setDispatcher(dispatcher);
     decrement.setDispatcher(dispatcher);
     increment.setDispatcher(dispatcher);
@@ -283,8 +292,11 @@ class _$NestedCounterActions extends NestedCounterActions {
 }
 
 class NestedCounterActionsNames {
-  static final ActionName<FooTypedef> fooTypedef =
-      new ActionName<FooTypedef>('NestedCounterActions-fooTypedef');
+  static final ActionName<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder, BaseCounterActions>>
+      thunkDispatcher = new ActionName<
+          ThunkTypedef<BaseCounter, BaseCounterBuilder,
+              BaseCounterActions>>('NestedCounterActions-thunkDispatcher');
   static final ActionName<Null> incrementOne =
       new ActionName<Null>('NestedCounterActions-incrementOne');
   static final ActionName<int> decrement =


### PR DESCRIPTION
Action dipatcher's whose payloads were thunks, repatches or any other type that had generics that contained Built/Builder pairs from the same library would result in the Builder being dynamic because the AST could not resolve the Builder. The resolution would fail because when build resolves the structure the Builder class had not yet been generated.

This checks if the generics bound params include Built, Builder and if so, renames the type argument proceeding the Built as the Built's type name + 'Builder'

This this will generate correctly:
```dart
typedef TypedefWithBuildGenerics<V extends Build<V, B>, V extends Builder<V, B>>()

...

ActionDispatcher<TypedefWithBuildGenerics<Foo, FooBuilder>> fooDispatcher;
```

but this would not:
```dart
typedef TypedefWithoutBoundGenerics<V, B>()
...

ActionDispatcher<TypedefWithoutBoundGenerics<Foo, FooBuilder>> fooDispatcher;
```