### PR TITLE
Open built value range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,12 +9,12 @@ dependencies:
   analyzer: '>=0.29.0 <0.31.0'
   build: '>=0.10.0 <0.12.0'
   built_collection: '>=1.0.0 <3.0.0'
-  built_value: ^4.1.0
+  built_value: '>=4.1.0 < 6.0.0'
   source_gen: ^0.7.0
 
 dev_dependencies:
   build_runner: ^0.6.0
-  built_value_generator: ^4.1.0
+  built_value_generator: '>=4.1.0 < 6.0.0'
   dart_dev: ^1.0.0
   dart_style: '>=0.2.4 <2.0.0'
   coverage: ^0.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_redux
-version: 7.3.3
+version: 7.3.4
 description:
   A state management library written in dart that enforces immutability
 authors:


### PR DESCRIPTION
Open built value range to include 5.0.0
The new line of built_value is completely compatible with built_redux without any additional changes 