### PR TITLE
fix cast issues around store changes in dart 2 & DDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.4.1
+
+* fix cast issues around store changes in dart 2
+
 ## 7.4.0
 
 * add built_redux_test_utils library - exposes an expectDispatched function for expecting a given action gets dispatched asynchronously

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -123,5 +123,9 @@ class Store<
           ActionName<Payload> actionName) =>
       stream
           .where((c) => c.action.name == actionName.name)
-          .map((c) => c as StoreChange<State, StateBuilder, Payload>);
+          .map((c) => new StoreChange<State, StateBuilder, Payload>(
+                c.next,
+                c.prev,
+                c.action as Action<Payload>,
+              ));
 }

--- a/lib/src/store_change.dart
+++ b/lib/src/store_change.dart
@@ -40,7 +40,11 @@ class StoreChangeHandlerBuilder<
   void add<Payload>(ActionName<Payload> actionName,
       StoreChangeHandler<Payload, State, StateBuilder> handler) {
     _map[actionName.name] = (change) {
-      handler(change as StoreChange<State, StateBuilder, Payload>);
+      handler(new StoreChange<State, StateBuilder, Payload>(
+        change.next,
+        change.prev,
+        change.action as Action<Payload>,
+      ));
     };
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_redux
-version: 7.4.0
+version: 7.4.1
 description:
   A state management library written in dart that enforces immutability
 authors:


### PR DESCRIPTION
Store change casts such as ` c as StoreChange<State, StateBuilder, Payload>` do not work. The action object in the StoreChange as to me casted itself.

Create a new StoreChange object that is the correct type rather than casting.