### PR TITLE
Adds an .addAll method to NestedReducerBuilder

### DIFF
--- a/lib/src/reducer_builder.dart
+++ b/lib/src/reducer_builder.dart
@@ -124,6 +124,17 @@ class NestedReducerBuilder<
 
   NestedReducerBuilder(this._stateMapper, this._builderMapper);
 
+  void addAll(ReducerBuilder<NestedState, NestedStateBuilder> other) {
+    final adapted = other._map.map((name, reducer) => MapEntry(
+        name,
+        (State state, Action<dynamic> action, StateBuilder builder) => reducer(
+              _stateMapper(state),
+              action,
+              _builderMapper(builder),
+            )));
+    _map.addAll(adapted);
+  }
+
   /// Registers [reducer] function to the given [actionName]
   void add<Payload>(ActionName<Payload> actionName,
       Reducer<NestedState, NestedStateBuilder, Payload> reducer) {

--- a/test/unit/nested_models.dart
+++ b/test/unit/nested_models.dart
@@ -73,7 +73,7 @@ Reducer<Base, BaseBuilder, dynamic> getBaseReducer() =>
     (new ReducerBuilder<Base, BaseBuilder>()
           ..add<Null>(BaseActionsNames.baseAction, (s, a, b) => b.count++)
           ..combineNested(getChildReducer())
-          ..combineNested(getGrandchildReducer()))
+          ..combineNested(getNestedGrandchildReducer()))
         .build();
 
 // getChildReducer returns a nested reducer builder that rebuilds the
@@ -93,10 +93,16 @@ NestedReducerBuilder<Base, BaseBuilder, Child, ChildBuilder>
 // Reducers added to the NestedReducerBuilder must have the signature:
 // (Grandchild, Action<T>, GrandchildBuilder)
 NestedReducerBuilder<Base, BaseBuilder, Grandchild, GrandchildBuilder>
-    getGrandchildReducer() => new NestedReducerBuilder<
+    getNestedGrandchildReducer() => new NestedReducerBuilder<
         Base,
         BaseBuilder,
         Grandchild,
         GrandchildBuilder>((s) => s.child.grandchild, (b) => b.child.grandchild)
+      ..addAll(getGrandchildReducer());
+
+ReducerBuilder<Grandchild, GrandchildBuilder> getGrandchildReducer() =>
+    new ReducerBuilder<
+        Grandchild,
+        GrandchildBuilder>()
       ..add<Null>(
           GrandchildActionsNames.grandchildAction, (s, a, b) => b.count++);


### PR DESCRIPTION
This allows users of the library to create reducers that only know about
a certain, related set of actions. Then, those reducers can be composed
into a higher-level reducer without needing to know about and add each
child action.

This should help users create reusable (packaged) modules since the
module's provided `ReducerBuilder` won't need to know the `State`
defined by the NestedReducerBuilder.

Closes #89 