### PR TITLE
Adds NestedMiddlewareBuilder

### DIFF
--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -10,14 +10,19 @@ class MiddlewareApi<
     State extends Built<State, StateBuilder>,
     StateBuilder extends Builder<State, StateBuilder>,
     Actions extends ReduxActions> {
-  Store<State, StateBuilder, Actions> _store;
-  MiddlewareApi(this._store);
+  final State Function() _state;
+  final Actions Function() _actions;
+
+  MiddlewareApi._(this._state, this._actions);
+
+  factory MiddlewareApi(Store<State, StateBuilder, Actions> _store) =>
+      MiddlewareApi._(() => _store.state, () => _store.actions);
 
   /// [state] returns the current state
-  State get state => _store.state;
+  State get state => _state();
 
   /// [actions] returns the actions synced with this redux store
-  Actions get actions => _store.actions;
+  Actions get actions => _actions();
 }
 
 /// [MiddlewareBuilder] allows you to build a reducer that handles many different actions
@@ -44,6 +49,16 @@ class MiddlewareBuilder<
     _map.addAll(other._map);
   }
 
+  void combineNested<
+          NestedState extends Built<NestedState, NestedStateBuilder>,
+          NestedStateBuilder extends Builder<NestedState, NestedStateBuilder>,
+          NestedActions extends ReduxActions>(
+      NestedMiddlewareBuilder<State, StateBuilder, Actions, NestedState,
+              NestedStateBuilder, NestedActions>
+          other) {
+    _map.addAll(other._map);
+  }
+
   /// [build] returns a [Middleware] function that handles all actions added with [add]
   Middleware<State, StateBuilder, Actions> build() =>
       (MiddlewareApi<State, StateBuilder, Actions> api) =>
@@ -58,9 +73,52 @@ class MiddlewareBuilder<
               };
 }
 
+class NestedMiddlewareBuilder<
+    State extends Built<State, StateBuilder>,
+    StateBuilder extends Builder<State, StateBuilder>,
+    Actions extends ReduxActions,
+    NestedState extends Built<NestedState, NestedStateBuilder>,
+    NestedStateBuilder extends Builder<NestedState, NestedStateBuilder>,
+    NestedActions extends ReduxActions> {
+  final _map =
+      Map<String, MiddlewareHandler<State, StateBuilder, Actions, dynamic>>();
+
+  final NestedState Function(State) _stateMapper;
+  final NestedActions Function(Actions) _actionsMapper;
+
+  NestedMiddlewareBuilder(this._stateMapper, this._actionsMapper);
+
+  void add<Payload>(
+      ActionName<Payload> aMgr,
+      MiddlewareHandler<NestedState, NestedStateBuilder, NestedActions, Payload>
+          handler) {
+    _map[aMgr.name] = (api, next, action) {
+      handler(
+          MiddlewareApi._(
+              () => _stateMapper(api.state), () => _actionsMapper(api.actions)),
+          next,
+          action as Action<Payload>);
+    };
+  }
+
+  void addAll(
+      MiddlewareBuilder<NestedState, NestedStateBuilder, NestedActions> other) {
+    var adapted = other._map.map((name, handler) => MapEntry(
+        name,
+        (MiddlewareApi<State, StateBuilder, Actions> api, ActionHandler next,
+                Action action) =>
+            handler(
+                MiddlewareApi._(() => _stateMapper(api.state),
+                    () => _actionsMapper(api.actions)),
+                next,
+                action)));
+    _map.addAll(adapted);
+  }
+}
+
 /// [MiddlewareHandler] is a function that handles an action in a middleware. Its is only for
 /// use with [MiddlewareBuilder]. If you are not using [MiddlewareBuilder] middleware must be
-/// decalred as a [Middleware] function.
+/// declared as a [Middleware] function.
 typedef void MiddlewareHandler<
     State extends Built<State, StateBuilder>,
     StateBuilder extends Builder<State, StateBuilder>,

--- a/test/unit/middleware_test.dart
+++ b/test/unit/middleware_test.dart
@@ -67,5 +67,12 @@ void main() {
       store.actions.middlewareActions.tripleIt(0);
       expect(store.state.count, 4);
     });
+
+    test('combineNested works with SubCounter doubleIt', () async {
+      setup();
+      expect(store.state.subCounter.subCount, 1);
+      store.actions.subCounterActions.doubleIt(0);
+      expect(store.state.subCounter.subCount, 3);
+    });
   });
 }

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -17,12 +17,14 @@ class _$CounterActions extends CounterActions {
       new ActionDispatcher<int>('CounterActions-increment');
   final ActionDispatcher<int> incrementOther =
       new ActionDispatcher<int>('CounterActions-incrementOther');
+  final SubCounterActions subCounterActions = new SubCounterActions();
   final MiddlewareActions middlewareActions = new MiddlewareActions();
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
     increment.setDispatcher(dispatcher);
     incrementOther.setDispatcher(dispatcher);
+    subCounterActions.setDispatcher(dispatcher);
     middlewareActions.setDispatcher(dispatcher);
   }
 }
@@ -32,6 +34,29 @@ class CounterActionsNames {
       new ActionName<int>('CounterActions-increment');
   static final ActionName<int> incrementOther =
       new ActionName<int>('CounterActions-incrementOther');
+}
+
+class _$SubCounterActions extends SubCounterActions {
+  factory _$SubCounterActions() => new _$SubCounterActions._();
+  _$SubCounterActions._() : super._();
+
+  final ActionDispatcher<int> increment =
+      new ActionDispatcher<int>('SubCounterActions-increment');
+  final ActionDispatcher<int> doubleIt =
+      new ActionDispatcher<int>('SubCounterActions-doubleIt');
+
+  @override
+  void setDispatcher(Dispatcher dispatcher) {
+    increment.setDispatcher(dispatcher);
+    doubleIt.setDispatcher(dispatcher);
+  }
+}
+
+class SubCounterActionsNames {
+  static final ActionName<int> increment =
+      new ActionName<int>('SubCounterActions-increment');
+  static final ActionName<int> doubleIt =
+      new ActionName<int>('SubCounterActions-doubleIt');
 }
 
 class _$MiddlewareActions extends MiddlewareActions {
@@ -76,14 +101,18 @@ class _$Counter extends Counter {
   final int count;
   @override
   final int otherCount;
+  @override
+  final SubCounter subCounter;
 
   factory _$Counter([void updates(CounterBuilder b)]) =>
       (new CounterBuilder()..update(updates)).build();
 
-  _$Counter._({this.count, this.otherCount}) : super._() {
+  _$Counter._({this.count, this.otherCount, this.subCounter}) : super._() {
     if (count == null) throw new BuiltValueNullFieldError('Counter', 'count');
     if (otherCount == null)
       throw new BuiltValueNullFieldError('Counter', 'otherCount');
+    if (subCounter == null)
+      throw new BuiltValueNullFieldError('Counter', 'subCounter');
   }
 
   @override
@@ -97,19 +126,23 @@ class _$Counter extends Counter {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! Counter) return false;
-    return count == other.count && otherCount == other.otherCount;
+    return count == other.count &&
+        otherCount == other.otherCount &&
+        subCounter == other.subCounter;
   }
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, count.hashCode), otherCount.hashCode));
+    return $jf($jc(
+        $jc($jc(0, count.hashCode), otherCount.hashCode), subCounter.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('Counter')
           ..add('count', count)
-          ..add('otherCount', otherCount))
+          ..add('otherCount', otherCount)
+          ..add('subCounter', subCounter))
         .toString();
   }
 }
@@ -125,12 +158,19 @@ class CounterBuilder implements Builder<Counter, CounterBuilder> {
   int get otherCount => _$this._otherCount;
   set otherCount(int otherCount) => _$this._otherCount = otherCount;
 
+  SubCounterBuilder _subCounter;
+  SubCounterBuilder get subCounter =>
+      _$this._subCounter ??= new SubCounterBuilder();
+  set subCounter(SubCounterBuilder subCounter) =>
+      _$this._subCounter = subCounter;
+
   CounterBuilder();
 
   CounterBuilder get _$this {
     if (_$v != null) {
       _count = _$v.count;
       _otherCount = _$v.otherCount;
+      _subCounter = _$v.subCounter?.toBuilder();
       _$v = null;
     }
     return this;
@@ -149,8 +189,99 @@ class CounterBuilder implements Builder<Counter, CounterBuilder> {
 
   @override
   _$Counter build() {
-    final _$result =
-        _$v ?? new _$Counter._(count: count, otherCount: otherCount);
+    _$Counter _$result;
+    try {
+      _$result = _$v ??
+          new _$Counter._(
+              count: count,
+              otherCount: otherCount,
+              subCounter: subCounter.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'subCounter';
+        subCounter.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Counter', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$SubCounter extends SubCounter {
+  @override
+  final int subCount;
+
+  factory _$SubCounter([void updates(SubCounterBuilder b)]) =>
+      (new SubCounterBuilder()..update(updates)).build();
+
+  _$SubCounter._({this.subCount}) : super._() {
+    if (subCount == null)
+      throw new BuiltValueNullFieldError('SubCounter', 'subCount');
+  }
+
+  @override
+  SubCounter rebuild(void updates(SubCounterBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SubCounterBuilder toBuilder() => new SubCounterBuilder()..replace(this);
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(other, this)) return true;
+    if (other is! SubCounter) return false;
+    return subCount == other.subCount;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, subCount.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('SubCounter')
+          ..add('subCount', subCount))
+        .toString();
+  }
+}
+
+class SubCounterBuilder implements Builder<SubCounter, SubCounterBuilder> {
+  _$SubCounter _$v;
+
+  int _subCount;
+  int get subCount => _$this._subCount;
+  set subCount(int subCount) => _$this._subCount = subCount;
+
+  SubCounterBuilder();
+
+  SubCounterBuilder get _$this {
+    if (_$v != null) {
+      _subCount = _$v.subCount;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SubCounter other) {
+    if (other == null) throw new ArgumentError.notNull('other');
+    _$v = other as _$SubCounter;
+  }
+
+  @override
+  void update(void updates(SubCounterBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$SubCounter build() {
+    final _$result = _$v ?? new _$SubCounter._(subCount: subCount);
     replace(_$result);
     return _$result;
   }


### PR DESCRIPTION
`NestedMiddlewareBuilder` can be used to adapt narrowly-focused
`Middleware` into one that can added to a larger project or app.

Closes #88 