### PR TITLE
Changes for angulasr 5.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,20 @@
 name: built_redux
-version: 7.5.2
+version: 7.5.3
 description:
   A state management library written in dart that enforces immutability
 authors:
 - David Marne <davemarne@gmail.com>
 homepage: https://github.com/davidmarne/built_redux
 dependencies:
-  analyzer: ^0.33.0
-  build: ^1.0.0
+  analyzer: '>=0.33.0 <1.0.0'
+  build: '>=1.0.0 < 1.1.0'
   built_collection: '>=2.0.0 <5.0.0'
   built_value: '>=5.5.5 <7.0.0'
   source_gen: ^0.9.0
   test: '>=0.12.0 <2.0.0'
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: '>=1.0.0 < 1.1.0'
   build_test: ^0.10.0
   built_value_generator: ^6.0.0
   build_web_compilers: ^1.0.0


### PR DESCRIPTION
I changed the version of build, build_runner and analyzer to ranges, as the caret notation only allows changes in the last zero numbers

Set version to 7.5.3