### PR TITLE
Widen analyzer range to include 0.36.x

### DIFF
--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -40,7 +40,7 @@ class _$Counter extends Counter {
   @override
   final int count;
 
-  factory _$Counter([void updates(CounterBuilder b)]) =>
+  factory _$Counter([void Function(CounterBuilder) updates]) =>
       (new CounterBuilder()..update(updates)).build();
 
   _$Counter._({this.count}) : super._() {
@@ -50,7 +50,7 @@ class _$Counter extends Counter {
   }
 
   @override
-  Counter rebuild(void updates(CounterBuilder b)) =>
+  Counter rebuild(void Function(CounterBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -100,7 +100,7 @@ class CounterBuilder implements Builder<Counter, CounterBuilder> {
   }
 
   @override
-  void update(void updates(CounterBuilder b)) {
+  void update(void Function(CounterBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
 - David Marne <davemarne@gmail.com>
 homepage: https://github.com/davidmarne/built_redux
 dependencies:
-  analyzer: '>=0.33.0 <0.36.0'
+  analyzer: '>=0.33.0 <0.37.0'
   build: ^1.0.0
   built_collection: '>=2.0.0 <5.0.0'
   built_value: '>=5.5.5 <7.0.0'
@@ -17,7 +17,7 @@ dev_dependencies:
   build_runner: ^1.0.0
   build_test: ^0.10.0
   built_value_generator: ^6.0.0
-  build_web_compilers: ^1.0.0
+  build_web_compilers: ^2.1.1
 
 environment:
   sdk: '>=2.0.0-dev <3.0.0'

--- a/test/unit/action_generics_models.g.dart
+++ b/test/unit/action_generics_models.g.dart
@@ -77,7 +77,7 @@ class _$ActionGenerics extends ActionGenerics {
   @override
   final int count;
 
-  factory _$ActionGenerics([void updates(ActionGenericsBuilder b)]) =>
+  factory _$ActionGenerics([void Function(ActionGenericsBuilder) updates]) =>
       (new ActionGenericsBuilder()..update(updates)).build();
 
   _$ActionGenerics._({this.count}) : super._() {
@@ -87,7 +87,7 @@ class _$ActionGenerics extends ActionGenerics {
   }
 
   @override
-  ActionGenerics rebuild(void updates(ActionGenericsBuilder b)) =>
+  ActionGenerics rebuild(void Function(ActionGenericsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -139,7 +139,7 @@ class ActionGenericsBuilder
   }
 
   @override
-  void update(void updates(ActionGenericsBuilder b)) {
+  void update(void Function(ActionGenericsBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/test/unit/collection_models.g.dart
+++ b/test/unit/collection_models.g.dart
@@ -63,7 +63,7 @@ class _$Collection extends Collection {
   @override
   final BuiltSetMultimap<int, int> builtSetMultimap;
 
-  factory _$Collection([void updates(CollectionBuilder b)]) =>
+  factory _$Collection([void Function(CollectionBuilder) updates]) =>
       (new CollectionBuilder()..update(updates)).build();
 
   _$Collection._(
@@ -91,7 +91,7 @@ class _$Collection extends Collection {
   }
 
   @override
-  Collection rebuild(void updates(CollectionBuilder b)) =>
+  Collection rebuild(void Function(CollectionBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -182,7 +182,7 @@ class CollectionBuilder implements Builder<Collection, CollectionBuilder> {
   }
 
   @override
-  void update(void updates(CollectionBuilder b)) {
+  void update(void Function(CollectionBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/test/unit/inheritance_test_models.g.dart
+++ b/test/unit/inheritance_test_models.g.dart
@@ -55,14 +55,14 @@ class GrandparentActionsNames {
 
 abstract class ParentBuilder {
   void replace(Parent other);
-  void update(void updates(ParentBuilder b));
+  void update(void Function(ParentBuilder) updates);
   int get parentCount;
   set parentCount(int parentCount);
 }
 
 abstract class GrandparentBuilder {
   void replace(Grandparent other);
-  void update(void updates(GrandparentBuilder b));
+  void update(void Function(GrandparentBuilder) updates);
   int get grandparentCount;
   set grandparentCount(int grandparentCount);
 }
@@ -75,7 +75,7 @@ class _$Child extends Child {
   @override
   final int grandparentCount;
 
-  factory _$Child([void updates(ChildBuilder b)]) =>
+  factory _$Child([void Function(ChildBuilder) updates]) =>
       (new ChildBuilder()..update(updates)).build();
 
   _$Child._({this.childCount, this.parentCount, this.grandparentCount})
@@ -92,7 +92,7 @@ class _$Child extends Child {
   }
 
   @override
-  Child rebuild(void updates(ChildBuilder b)) =>
+  Child rebuild(void Function(ChildBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -162,7 +162,7 @@ class ChildBuilder
   }
 
   @override
-  void update(void updates(ChildBuilder b)) {
+  void update(void Function(ChildBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/test/unit/nested_models.g.dart
+++ b/test/unit/nested_models.g.dart
@@ -77,7 +77,7 @@ class _$Base extends Base {
   @override
   final Child child;
 
-  factory _$Base([void updates(BaseBuilder b)]) =>
+  factory _$Base([void Function(BaseBuilder) updates]) =>
       (new BaseBuilder()..update(updates)).build();
 
   _$Base._({this.count, this.child}) : super._() {
@@ -90,7 +90,7 @@ class _$Base extends Base {
   }
 
   @override
-  Base rebuild(void updates(BaseBuilder b)) =>
+  Base rebuild(void Function(BaseBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -147,7 +147,7 @@ class BaseBuilder implements Builder<Base, BaseBuilder> {
   }
 
   @override
-  void update(void updates(BaseBuilder b)) {
+  void update(void Function(BaseBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -178,7 +178,7 @@ class _$Child extends Child {
   @override
   final Grandchild grandchild;
 
-  factory _$Child([void updates(ChildBuilder b)]) =>
+  factory _$Child([void Function(ChildBuilder) updates]) =>
       (new ChildBuilder()..update(updates)).build();
 
   _$Child._({this.count, this.grandchild}) : super._() {
@@ -191,7 +191,7 @@ class _$Child extends Child {
   }
 
   @override
-  Child rebuild(void updates(ChildBuilder b)) =>
+  Child rebuild(void Function(ChildBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -252,7 +252,7 @@ class ChildBuilder implements Builder<Child, ChildBuilder> {
   }
 
   @override
-  void update(void updates(ChildBuilder b)) {
+  void update(void Function(ChildBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -282,7 +282,7 @@ class _$Grandchild extends Grandchild {
   @override
   final int count;
 
-  factory _$Grandchild([void updates(GrandchildBuilder b)]) =>
+  factory _$Grandchild([void Function(GrandchildBuilder) updates]) =>
       (new GrandchildBuilder()..update(updates)).build();
 
   _$Grandchild._({this.count}) : super._() {
@@ -292,7 +292,7 @@ class _$Grandchild extends Grandchild {
   }
 
   @override
-  Grandchild rebuild(void updates(GrandchildBuilder b)) =>
+  Grandchild rebuild(void Function(GrandchildBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -342,7 +342,7 @@ class GrandchildBuilder implements Builder<Grandchild, GrandchildBuilder> {
   }
 
   @override
-  void update(void updates(GrandchildBuilder b)) {
+  void update(void Function(GrandchildBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -94,7 +94,7 @@ class _$Counter extends Counter {
   @override
   final SubCounter subCounter;
 
-  factory _$Counter([void updates(CounterBuilder b)]) =>
+  factory _$Counter([void Function(CounterBuilder) updates]) =>
       (new CounterBuilder()..update(updates)).build();
 
   _$Counter._({this.count, this.otherCount, this.subCounter}) : super._() {
@@ -110,7 +110,7 @@ class _$Counter extends Counter {
   }
 
   @override
-  Counter rebuild(void updates(CounterBuilder b)) =>
+  Counter rebuild(void Function(CounterBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -179,7 +179,7 @@ class CounterBuilder implements Builder<Counter, CounterBuilder> {
   }
 
   @override
-  void update(void updates(CounterBuilder b)) {
+  void update(void Function(CounterBuilder) updates) {
     if (updates != null) updates(this);
   }
 
@@ -212,7 +212,7 @@ class _$SubCounter extends SubCounter {
   @override
   final int subCount;
 
-  factory _$SubCounter([void updates(SubCounterBuilder b)]) =>
+  factory _$SubCounter([void Function(SubCounterBuilder) updates]) =>
       (new SubCounterBuilder()..update(updates)).build();
 
   _$SubCounter._({this.subCount}) : super._() {
@@ -222,7 +222,7 @@ class _$SubCounter extends SubCounter {
   }
 
   @override
-  SubCounter rebuild(void updates(SubCounterBuilder b)) =>
+  SubCounter rebuild(void Function(SubCounterBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -273,7 +273,7 @@ class SubCounterBuilder implements Builder<SubCounter, SubCounterBuilder> {
   }
 
   @override
-  void update(void updates(SubCounterBuilder b)) {
+  void update(void Function(SubCounterBuilder) updates) {
     if (updates != null) updates(this);
   }
 


### PR DESCRIPTION
Some of the latest `build_*` packages have started requiring at least analyzer 0.36.0. I tried it out locally by upgrading to analyzer 0.36.3, and all tests still pass.

@davidmarne 