### PR TITLE
Increase Analyzer Upper Bound

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
 - David Marne <davemarne@gmail.com>
 homepage: https://github.com/davidmarne/built_redux
 dependencies:
-  analyzer: '>=0.33.0 <0.37.0'
+  analyzer: '>=0.33.0 <0.39.0'
   build: ^1.0.0
   built_collection: '>=2.0.0 <5.0.0'
   built_value: '>=5.5.5 <7.0.0'


### PR DESCRIPTION
Upper bounds of the `analyzer` version need to be increased so that we aren't prevented from pulling newer versions of packages (e.g., build_web_compilers) that depend on newer versions of `analyzer` (see the ticket [here](https://jira.atl.workiva.net/browse/CPLAT-7674)).

Because built_redux is dependency for over_react, it also needs to be updated.