### PR TITLE
Allow built_value/built_value_generator 7.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,14 +9,14 @@ dependencies:
   analyzer: '>=0.33.0 <0.39.0'
   build: ^1.0.0
   built_collection: '>=2.0.0 <5.0.0'
-  built_value: '>=5.5.5 <7.0.0'
+  built_value: '>=5.5.5 <8.0.0'
   source_gen: ^0.9.0
   test: '>=0.12.0 <2.0.0'
 
 dev_dependencies:
   build_runner: ^1.0.0
   build_test: ^0.10.0
-  built_value_generator: ^6.0.0
+  built_value_generator: '>=6.0.0 <8.0.0'
   build_web_compilers: ^2.1.1
 
 environment:


### PR DESCRIPTION
This will help unblock downstream deps from upgrading to 7.x