### PR TITLE
7.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.5.8
+
+* rework generator to lift analyzer version constraint.
+* open analyzer range
+* generator now uses source parsing to resolve action generic types which allows any unresolved type to be used as an action payload.
+* generated actions classes now use type inference.
+* bump built_value lower bound to 6.1.4 since it is impossible for pub to resolve to anything lower due to the build dependency constraint.
+
 ## 7.5.7
 open built value range
 restrict analyzer to less than 0.38.3, issue was introduced in 0.38.3 patch

--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -24,10 +24,8 @@ class _$CounterActions extends CounterActions {
 }
 
 class CounterActionsNames {
-  static final ActionName<int> increment =
-      new ActionName('CounterActions-increment');
-  static final ActionName<int> decrement =
-      new ActionName('CounterActions-decrement');
+  static final increment = new ActionName<int>('CounterActions-increment');
+  static final decrement = new ActionName<int>('CounterActions-decrement');
 }
 
 // **************************************************************************

--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -8,6 +8,7 @@ part of example;
 
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 
 class _$CounterActions extends CounterActions {
   factory _$CounterActions() => new _$CounterActions._();

--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -13,10 +13,8 @@ class _$CounterActions extends CounterActions {
   factory _$CounterActions() => new _$CounterActions._();
   _$CounterActions._() : super._();
 
-  final ActionDispatcher<int> increment =
-      new ActionDispatcher<int>('CounterActions-increment');
-  final ActionDispatcher<int> decrement =
-      new ActionDispatcher<int>('CounterActions-decrement');
+  final increment = new ActionDispatcher<int>('CounterActions-increment');
+  final decrement = new ActionDispatcher<int>('CounterActions-decrement');
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
@@ -27,9 +25,9 @@ class _$CounterActions extends CounterActions {
 
 class CounterActionsNames {
   static final ActionName<int> increment =
-      new ActionName<int>('CounterActions-increment');
+      new ActionName('CounterActions-increment');
   static final ActionName<int> decrement =
-      new ActionName<int>('CounterActions-decrement');
+      new ActionName('CounterActions-decrement');
 }
 
 // **************************************************************************

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -10,7 +9,7 @@ class BuiltReduxGenerator extends Generator {
     final result = new StringBuffer();
     var hasWrittenHeaders = false;
     for (final element in library.allElements) {
-      if (_needsReduxActions(element) && element is ClassElement) {
+      if (_isReduxActions(element) && element is ClassElement) {
         if (!hasWrittenHeaders) {
           hasWrittenHeaders = true;
           result.writeln(_lintIgnores);
@@ -29,12 +28,78 @@ const _lintIgnores = """
 // ignore_for_file: annotate_overrides
 """;
 
-String _generateActions(ClassElement element) =>
-    _generateDispatchersIfNeeded(element) + _actionNamesClassTemplate(element);
+ActionsClass _actionsClassFromElement(ClassElement element) => new ActionsClass(
+      element.name,
+      _actionsFromElement(element).toSet(),
+      _composedActionClasses(element).toSet(),
+      _actionsClassFromInheritedElements(element).toSet(),
+    );
 
-String _generateDispatchersIfNeeded(ClassElement element) =>
+Iterable<ComposedActionClass> _composedActionClasses(ClassElement element) =>
+    element.fields
+        .where((f) => _isReduxActions(f.type.element))
+        .map((f) => new ComposedActionClass(f.name, f.type.name));
+
+Iterable<Action> _actionsFromElement(ClassElement element) => element.fields
+    .where(_isActionDispatcher)
+    .map((field) => _fieldElementToAction(element, field));
+
+Iterable<ActionsClass> _actionsClassFromInheritedElements(
+        ClassElement element) =>
+    element.allSupertypes
+        .map((s) => s.element)
+        .where(_isReduxActions)
+        .map(_actionsClassFromElement);
+
+Action _fieldElementToAction(ClassElement element, FieldElement field) =>
+    new Action('${element.name}-${field.name}', field.name,
+        _fieldType(element, field));
+
+// hack to return the generics for the action
+// this is used so action whose payloads are of generated types
+// will not result in dynamic
+String _fieldType(ClassElement element, FieldElement field) {
+  if (field.isSynthetic) {
+    return _syntheticFieldType(element, field);
+  }
+  return _getGenerics(field.source.contents.data, field.nameOffset);
+}
+
+String _syntheticFieldType(ClassElement element, FieldElement field) {
+  final method = element.getGetter(field.name);
+  return _getGenerics(method.source.contents.data, method.nameOffset);
+}
+
+String _getGenerics(String source, int nameOffset) {
+  final trimAfterName = source.substring(0, nameOffset);
+  final trimBeforeActionDispatcher =
+      trimAfterName.substring(trimAfterName.lastIndexOf('ActionDispatcher'));
+  return trimBeforeActionDispatcher.substring(
+      trimBeforeActionDispatcher.indexOf('<') + 1,
+      trimBeforeActionDispatcher.lastIndexOf('>'));
+}
+
+bool _isReduxActions(Element element) =>
+    element is ClassElement && _hasSuperType(element, 'ReduxActions');
+
+bool _isActionDispatcher(FieldElement element) =>
+    element.type.name == 'ActionDispatcher';
+
+bool _hasSuperType(ClassElement classElement, String type) =>
+    classElement.allSupertypes
+        .any((interfaceType) => interfaceType.name == type) &&
+    !classElement.displayName.startsWith('_\$');
+
+String _generateActions(ClassElement element) {
+  final actionClass = _actionsClassFromElement(element);
+  return _generateDispatchersIfNeeded(element, actionClass) +
+      _actionNamesClassTemplate(actionClass);
+}
+
+String _generateDispatchersIfNeeded(
+        ClassElement element, ActionsClass actionsClass) =>
     element.constructors.length > 1
-        ? _actionDispatcherClassTemplate(element)
+        ? _actionDispatcherClassTemplate(actionsClass)
         : '';
 
 /*
@@ -43,167 +108,120 @@ String _generateDispatchersIfNeeded(ClassElement element) =>
 
 */
 
-String _actionDispatcherClassTemplate(ClassElement element) => '''
-  class _\$${element.name} extends ${element.name}{
-    factory _\$${element.name}() => new _\$${element.name}._();
-    _\$${element.name}._() : super._();
+String _actionDispatcherClassTemplate(ActionsClass actionsClass) => '''
+  class _\$${actionsClass.className} extends ${actionsClass.className}{
+    factory _\$${actionsClass.className}() => new _\$${actionsClass.className}._();
+    _\$${actionsClass.className}._() : super._();
 
-    ${_allActionDispatcherFieldsTemplate(element)}
+    ${_allActionDispatcherFieldsTemplate(actionsClass)}
+    ${_allComposedActionClassesFieldsTemplate(actionsClass)}
 
     @override
     void setDispatcher(Dispatcher dispatcher) {
-      ${_allSetDispatchersTemplate(element)}
+      ${_allActionDispatcherSetDispatchersTemplate(actionsClass)}
+      ${_allComposedActionClassesSetDispatchersTemplate(actionsClass)}
     }
   }
 ''';
 
-String _allActionDispatcherFieldsTemplate(ClassElement element) =>
-    _forEachFieldWithInherited(
-        element, _actionDispatcherFieldTemplate, _isActionDispatcher) +
-    _forEachFieldWithInherited(
-        element, _reduxActionFieldTemplate, _needsReduxActions);
+String _allActionDispatcherFieldsTemplate(ActionsClass actionsClass) =>
+    actionsClass.allActions.fold(
+        '', (comb, next) => '$comb\n${_actionDispatcherFieldTemplate(next)}');
 
-String _actionDispatcherFieldTemplate(ClassElement e, FieldElement f) {
-  final genericType =
-      _getActionGenericType((f.type as InterfaceType).typeArguments.first);
-  return 'final ActionDispatcher<${genericType}> ${f.name} = new ActionDispatcher<${genericType}>(\'${e.name}-${f.name}\');';
-}
+String _allComposedActionClassesFieldsTemplate(ActionsClass actionsClass) =>
+    actionsClass.allComposed.fold('',
+        (comb, next) => '$comb\n${_composedActionClassesFieldTemplate(next)}');
 
-String _reduxActionFieldTemplate(ClassElement e, FieldElement f) {
-  final typeName = f.type.element.name;
-  return 'final $typeName ${f.name} = new $typeName();';
-}
+String _actionDispatcherFieldTemplate(Action action) =>
+    'final ${action.fieldName} = new  ActionDispatcher<${action.type}>(\'${action.actionName}\');';
 
-String _allSetDispatchersTemplate(ClassElement element) =>
-    _forEachFieldWithInherited(
-        element, _setDispatcheTemplate, _isActionDispatcher) +
-    _forEachFieldWithInherited(
-        element, _setDispatcheTemplate, _needsReduxActions);
+String _composedActionClassesFieldTemplate(
+        ComposedActionClass composedActionClass) =>
+    'final ${composedActionClass.fieldName} = new ${composedActionClass.type}();';
 
-String _setDispatcheTemplate(ClassElement e, FieldElement f) =>
-    '${f.name}.setDispatcher(dispatcher);';
+String _allActionDispatcherSetDispatchersTemplate(ActionsClass actionsClass) =>
+    actionsClass.allActions.fold(
+        '', (comb, next) => '$comb\n${_setDispatcheTemplate(next.fieldName)}');
 
-/*
+String _allComposedActionClassesSetDispatchersTemplate(
+        ActionsClass actionsClass) =>
+    actionsClass.allComposed.fold(
+        '', (comb, next) => '$comb\n${_setDispatcheTemplate(next.fieldName)}');
 
-  Action Names
+String _setDispatcheTemplate(String fieldName) =>
+    '${fieldName}.setDispatcher(dispatcher);';
 
-*/
+// /*
 
-String _actionNamesClassTemplate(ClassElement element) => '''
-  class ${element.name}Names {
-    ${_allActionNamesFieldsTemplate(element)}
+//   Action Names
+
+// */
+
+String _actionNamesClassTemplate(ActionsClass actionsClass) => '''
+  class ${actionsClass.className}Names {
+    ${_allActionNamesFieldsTemplate(actionsClass)}
   }
 ''';
 
-String _allActionNamesFieldsTemplate(ClassElement element) =>
-    _forEachFieldWithInherited(
-        element, _actionNameTemplate, _isActionDispatcher);
+String _allActionNamesFieldsTemplate(ActionsClass actionsClass) =>
+    actionsClass.allActions
+        .fold('', (comb, next) => '$comb\n${_actionNameTemplate(next)}');
 
-String _actionNameTemplate(ClassElement e, FieldElement f) {
-  final genericType =
-      _getActionGenericType((f.type as InterfaceType).typeArguments.first);
-  return 'static final ActionName<${genericType}> ${f.name} = new ActionName<${genericType}>(\'${e.name}-${f.name}\');';
+String _actionNameTemplate(Action action) =>
+    'static final ActionName<${action.type}> ${action.fieldName} = new ActionName(\'${action.actionName}\');';
+
+class ActionsClass {
+  final String className;
+  final Set<Action> actions;
+  final Set<ComposedActionClass> composed;
+  final Set<ActionsClass> inherited;
+  ActionsClass(this.className, this.actions, this.composed, this.inherited);
+  Set<Action> get allActions => new Set<Action>.from(
+        actions.toList()
+          ..addAll(inherited.map((ac) => ac.actions).expand((a) => a)),
+      );
+  Set<ComposedActionClass> get allComposed => new Set<ComposedActionClass>.from(
+        composed.toList()
+          ..addAll(inherited.map((ac) => ac.composed).expand((c) => c)),
+      );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ActionsClass && className == other.className;
+  }
+
+  @override
+  int get hashCode => className.hashCode;
 }
 
-/*
+class Action {
+  final String actionName;
+  final String fieldName;
+  final String type;
+  Action(this.actionName, this.fieldName, this.type);
 
-  Util
-
-*/
-String _forEachField(
-  ClassElement element,
-  String fieldTemplate(ClassElement e, FieldElement f),
-  bool fieldTest(Element e),
-) =>
-    element.fields
-        .where(
-          (f) => fieldTest(f.type.element),
-        )
-        .fold(
-          '',
-          (combined, next) => '$combined${fieldTemplate(element, next)}',
-        );
-
-String _forEachFieldWithInherited(
-  ClassElement element,
-  String fieldTemplate(ClassElement e, FieldElement f),
-  bool fieldTest(Element e),
-) =>
-    element.allSupertypes
-        .map(
-          (s) => _forEachField(s.element, fieldTemplate, fieldTest),
-        )
-        .fold(
-          _forEachField(element, fieldTemplate, fieldTest),
-          (combined, next) => '$combined$next',
-        );
-
-bool _needsReduxActions(Element element) =>
-    element is ClassElement && _hasSuperType(element, 'ReduxActions');
-
-bool _isActionDispatcher(Element element) =>
-    element is ClassElement && element.name == 'ActionDispatcher';
-
-bool _hasSuperType(ClassElement classElement, String type) =>
-    classElement.allSupertypes
-        .any((interfaceType) => interfaceType.name == type) &&
-    !classElement.displayName.startsWith('_\$');
-
-String _getActionGenericType(DartType type) {
-  if (type is FunctionType) {
-    final generics =
-        _correctUnresolvedGenerics(type.typeArguments, type.typeParameters);
-    if (generics.isEmpty) return typeNameOf(type);
-    return typeNameOf(type) + '<${generics.join(',')}>';
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Action && fieldName == other.fieldName;
   }
 
-  if (type is ParameterizedType) {
-    final generics =
-        _correctUnresolvedGenerics(type.typeArguments, type.typeParameters);
-    if (generics.isEmpty) return type.name;
-    return type.name + '<${generics.join(',')}>';
-  }
-
-  if (type.isVoid) return 'void';
-
-  return 'dynamic';
+  @override
+  int get hashCode => fieldName.hashCode;
 }
 
-List<String> _correctUnresolvedGenerics(
-    List<DartType> args, List<TypeParameterElement> params) {
-  // hack for thunks/repatches or any other type argument list where
-  // any given argument is a Built and the proceding is a Builder
-  // and the builder is dynamic in the typeArguments list becauses it is
-  // yet to be generated. This is complex and a bit awkward but
-  // it is written this way to be very careful not to make any unintended
-  // changes the the typeArguments list.
-  final typeArguments = args.map((ta) => ta.toString()).toList();
-  final boundParams = params.map((e) => e.bound);
-  for (int i = 0; i < boundParams.length; i++) {
-    // get the bound param at this spot
-    final b = boundParams.elementAt(i);
+class ComposedActionClass {
+  final String fieldName;
+  final String type;
+  ComposedActionClass(this.fieldName, this.type);
 
-    // if it is a Built and there is another argument after it
-    // check if it is supposed to be a Builder
-    if (b != null &&
-        b.name.startsWith('Built') &&
-        i != boundParams.length - 1) {
-      final next = boundParams.elementAt(i + 1);
-      if (next != null &&
-          next.name.startsWith('Builder') &&
-          typeArguments.elementAt(i + 1) == 'dynamic') {
-        log.info(
-            "replacing unresolved builder name ${typeArguments.elementAt(i)}Builder");
-        // if it is a builder replace typeArguments at this location as
-        // the Built's name + Builder
-        typeArguments.replaceRange(
-          i + 1,
-          i + 2,
-          ['${typeArguments.elementAt(i)}Builder'],
-        );
-      }
-    }
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Action && fieldName == other.fieldName;
   }
 
-  return typeArguments;
+  @override
+  int get hashCode => fieldName.hashCode;
 }

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -168,7 +168,7 @@ String _allActionNamesFieldsTemplate(ActionsClass actionsClass) =>
         .fold('', (comb, next) => '$comb\n${_actionNameTemplate(next)}');
 
 String _actionNameTemplate(Action action) =>
-    'static final ActionName<${action.type}> ${action.fieldName} = new ActionName(\'${action.actionName}\');';
+    'static final ${action.fieldName} = new ActionName<${action.type}>(\'${action.actionName}\');';
 
 class ActionsClass {
   final String className;

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -26,6 +26,7 @@ class BuiltReduxGenerator extends Generator {
 const _lintIgnores = """
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 """;
 
 ActionsClass _actionsClassFromElement(ClassElement element) => new ActionsClass(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: built_redux
-version: 7.5.7
+version: 7.5.8
 description:
   A state management library written in dart that enforces immutability
 authors:
 - David Marne <davemarne@gmail.com>
 homepage: https://github.com/davidmarne/built_redux
 dependencies:
-  analyzer: '>=0.33.0 <0.38.3' # issue resolving type parameters exist in 0.38.3 
+  analyzer: '>=0.33.0 <0.39.0'
   build: ^1.0.0
   built_collection: '>=2.0.0 <5.0.0'
-  built_value: '>=5.5.5 <8.0.0'
+  built_value: '>=6.1.4 <8.0.0' # 6.1.4 allowd build 1.0.0
   source_gen: ^0.9.0
   test: '>=0.12.0 <2.0.0'
 

--- a/test/unit/action_generics_models.dart
+++ b/test/unit/action_generics_models.dart
@@ -26,6 +26,7 @@ abstract class ActionGenericsActions extends ReduxActions {
 
   ActionDispatcher<int> get intAction;
   ActionDispatcher<Null> get nullAction;
+  ActionDispatcher<Set<int>> get setIntAction;
   ActionDispatcher<List<int>> get listIntAction;
   ActionDispatcher<Map<String, List<int>>> get mapStringToListIntAction;
   ActionDispatcher<

--- a/test/unit/action_generics_models.g.dart
+++ b/test/unit/action_generics_models.g.dart
@@ -13,31 +13,30 @@ class _$ActionGenericsActions extends ActionGenericsActions {
   factory _$ActionGenericsActions() => new _$ActionGenericsActions._();
   _$ActionGenericsActions._() : super._();
 
-  final ActionDispatcher<int> intAction =
+  final intAction =
       new ActionDispatcher<int>('ActionGenericsActions-intAction');
-  final ActionDispatcher<Null> nullAction =
+  final nullAction =
       new ActionDispatcher<Null>('ActionGenericsActions-nullAction');
-  final ActionDispatcher<List<int>> listIntAction =
+  final setIntAction =
+      new ActionDispatcher<Set<int>>('ActionGenericsActions-setIntAction');
+  final listIntAction =
       new ActionDispatcher<List<int>>('ActionGenericsActions-listIntAction');
-  final ActionDispatcher<Map<String, List<int>>> mapStringToListIntAction =
-      new ActionDispatcher<Map<String, List<int>>>(
-          'ActionGenericsActions-mapStringToListIntAction');
-  final ActionDispatcher<
-      ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
-          ActionGenericsActions>> typdefAction = new ActionDispatcher<
+  final mapStringToListIntAction = new ActionDispatcher<Map<String, List<int>>>(
+      'ActionGenericsActions-mapStringToListIntAction');
+  final typdefAction = new ActionDispatcher<
       ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
           ActionGenericsActions>>('ActionGenericsActions-typdefAction');
-  final ActionDispatcher<Foo<int>> fooAction =
+  final fooAction =
       new ActionDispatcher<Foo<int>>('ActionGenericsActions-fooAction');
-  final ActionDispatcher<ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>
-      classWithBuiltAction = new ActionDispatcher<
-              ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>(
-          'ActionGenericsActions-classWithBuiltAction');
+  final classWithBuiltAction = new ActionDispatcher<
+          ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>(
+      'ActionGenericsActions-classWithBuiltAction');
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
     intAction.setDispatcher(dispatcher);
     nullAction.setDispatcher(dispatcher);
+    setIntAction.setDispatcher(dispatcher);
     listIntAction.setDispatcher(dispatcher);
     mapStringToListIntAction.setDispatcher(dispatcher);
     typdefAction.setDispatcher(dispatcher);
@@ -48,25 +47,24 @@ class _$ActionGenericsActions extends ActionGenericsActions {
 
 class ActionGenericsActionsNames {
   static final ActionName<int> intAction =
-      new ActionName<int>('ActionGenericsActions-intAction');
+      new ActionName('ActionGenericsActions-intAction');
   static final ActionName<Null> nullAction =
-      new ActionName<Null>('ActionGenericsActions-nullAction');
+      new ActionName('ActionGenericsActions-nullAction');
+  static final ActionName<Set<int>> setIntAction =
+      new ActionName('ActionGenericsActions-setIntAction');
   static final ActionName<List<int>> listIntAction =
-      new ActionName<List<int>>('ActionGenericsActions-listIntAction');
+      new ActionName('ActionGenericsActions-listIntAction');
   static final ActionName<Map<String, List<int>>> mapStringToListIntAction =
-      new ActionName<Map<String, List<int>>>(
-          'ActionGenericsActions-mapStringToListIntAction');
+      new ActionName('ActionGenericsActions-mapStringToListIntAction');
   static final ActionName<
-      ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
-          ActionGenericsActions>> typdefAction = new ActionName<
-      ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
-          ActionGenericsActions>>('ActionGenericsActions-typdefAction');
+          ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
+              ActionGenericsActions>> typdefAction =
+      new ActionName('ActionGenericsActions-typdefAction');
   static final ActionName<Foo<int>> fooAction =
-      new ActionName<Foo<int>>('ActionGenericsActions-fooAction');
+      new ActionName('ActionGenericsActions-fooAction');
   static final ActionName<ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>
       classWithBuiltAction =
-      new ActionName<ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>(
-          'ActionGenericsActions-classWithBuiltAction');
+      new ActionName('ActionGenericsActions-classWithBuiltAction');
 }
 
 // **************************************************************************

--- a/test/unit/action_generics_models.g.dart
+++ b/test/unit/action_generics_models.g.dart
@@ -8,6 +8,7 @@ part of action_generics_models;
 
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 
 class _$ActionGenericsActions extends ActionGenericsActions {
   factory _$ActionGenericsActions() => new _$ActionGenericsActions._();

--- a/test/unit/action_generics_models.g.dart
+++ b/test/unit/action_generics_models.g.dart
@@ -46,25 +46,25 @@ class _$ActionGenericsActions extends ActionGenericsActions {
 }
 
 class ActionGenericsActionsNames {
-  static final ActionName<int> intAction =
-      new ActionName('ActionGenericsActions-intAction');
-  static final ActionName<Null> nullAction =
-      new ActionName('ActionGenericsActions-nullAction');
-  static final ActionName<Set<int>> setIntAction =
-      new ActionName('ActionGenericsActions-setIntAction');
-  static final ActionName<List<int>> listIntAction =
-      new ActionName('ActionGenericsActions-listIntAction');
-  static final ActionName<Map<String, List<int>>> mapStringToListIntAction =
-      new ActionName('ActionGenericsActions-mapStringToListIntAction');
-  static final ActionName<
-          ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
-              ActionGenericsActions>> typdefAction =
-      new ActionName('ActionGenericsActions-typdefAction');
-  static final ActionName<Foo<int>> fooAction =
-      new ActionName('ActionGenericsActions-fooAction');
-  static final ActionName<ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>
-      classWithBuiltAction =
-      new ActionName('ActionGenericsActions-classWithBuiltAction');
+  static final intAction =
+      new ActionName<int>('ActionGenericsActions-intAction');
+  static final nullAction =
+      new ActionName<Null>('ActionGenericsActions-nullAction');
+  static final setIntAction =
+      new ActionName<Set<int>>('ActionGenericsActions-setIntAction');
+  static final listIntAction =
+      new ActionName<List<int>>('ActionGenericsActions-listIntAction');
+  static final mapStringToListIntAction =
+      new ActionName<Map<String, List<int>>>(
+          'ActionGenericsActions-mapStringToListIntAction');
+  static final typdefAction = new ActionName<
+      ThunkTypedef<ActionGenerics, ActionGenericsBuilder,
+          ActionGenericsActions>>('ActionGenericsActions-typdefAction');
+  static final fooAction =
+      new ActionName<Foo<int>>('ActionGenericsActions-fooAction');
+  static final classWithBuiltAction =
+      new ActionName<ClassWithBuilt<ActionGenerics, ActionGenericsBuilder>>(
+          'ActionGenericsActions-classWithBuiltAction');
 }
 
 // **************************************************************************

--- a/test/unit/collection_models.g.dart
+++ b/test/unit/collection_models.g.dart
@@ -35,16 +35,16 @@ class _$CollectionActions extends CollectionActions {
 }
 
 class CollectionActionsNames {
-  static final ActionName<Null> builtListAction =
-      new ActionName('CollectionActions-builtListAction');
-  static final ActionName<Null> builtListMultimapAction =
-      new ActionName('CollectionActions-builtListMultimapAction');
-  static final ActionName<Null> builtMapAction =
-      new ActionName('CollectionActions-builtMapAction');
-  static final ActionName<Null> builtSetAction =
-      new ActionName('CollectionActions-builtSetAction');
-  static final ActionName<Null> builtSetMultimapAction =
-      new ActionName('CollectionActions-builtSetMultimapAction');
+  static final builtListAction =
+      new ActionName<Null>('CollectionActions-builtListAction');
+  static final builtListMultimapAction =
+      new ActionName<Null>('CollectionActions-builtListMultimapAction');
+  static final builtMapAction =
+      new ActionName<Null>('CollectionActions-builtMapAction');
+  static final builtSetAction =
+      new ActionName<Null>('CollectionActions-builtSetAction');
+  static final builtSetMultimapAction =
+      new ActionName<Null>('CollectionActions-builtSetMultimapAction');
 }
 
 // **************************************************************************

--- a/test/unit/collection_models.g.dart
+++ b/test/unit/collection_models.g.dart
@@ -8,6 +8,7 @@ part of collection_models;
 
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 
 class _$CollectionActions extends CollectionActions {
   factory _$CollectionActions() => new _$CollectionActions._();

--- a/test/unit/collection_models.g.dart
+++ b/test/unit/collection_models.g.dart
@@ -13,15 +13,15 @@ class _$CollectionActions extends CollectionActions {
   factory _$CollectionActions() => new _$CollectionActions._();
   _$CollectionActions._() : super._();
 
-  final ActionDispatcher<Null> builtListAction =
+  final builtListAction =
       new ActionDispatcher<Null>('CollectionActions-builtListAction');
-  final ActionDispatcher<Null> builtListMultimapAction =
+  final builtListMultimapAction =
       new ActionDispatcher<Null>('CollectionActions-builtListMultimapAction');
-  final ActionDispatcher<Null> builtMapAction =
+  final builtMapAction =
       new ActionDispatcher<Null>('CollectionActions-builtMapAction');
-  final ActionDispatcher<Null> builtSetAction =
+  final builtSetAction =
       new ActionDispatcher<Null>('CollectionActions-builtSetAction');
-  final ActionDispatcher<Null> builtSetMultimapAction =
+  final builtSetMultimapAction =
       new ActionDispatcher<Null>('CollectionActions-builtSetMultimapAction');
 
   @override
@@ -36,15 +36,15 @@ class _$CollectionActions extends CollectionActions {
 
 class CollectionActionsNames {
   static final ActionName<Null> builtListAction =
-      new ActionName<Null>('CollectionActions-builtListAction');
+      new ActionName('CollectionActions-builtListAction');
   static final ActionName<Null> builtListMultimapAction =
-      new ActionName<Null>('CollectionActions-builtListMultimapAction');
+      new ActionName('CollectionActions-builtListMultimapAction');
   static final ActionName<Null> builtMapAction =
-      new ActionName<Null>('CollectionActions-builtMapAction');
+      new ActionName('CollectionActions-builtMapAction');
   static final ActionName<Null> builtSetAction =
-      new ActionName<Null>('CollectionActions-builtSetAction');
+      new ActionName('CollectionActions-builtSetAction');
   static final ActionName<Null> builtSetMultimapAction =
-      new ActionName<Null>('CollectionActions-builtSetMultimapAction');
+      new ActionName('CollectionActions-builtSetMultimapAction');
 }
 
 // **************************************************************************

--- a/test/unit/inheritance_test_models.g.dart
+++ b/test/unit/inheritance_test_models.g.dart
@@ -27,24 +27,23 @@ class _$ChildActions extends ChildActions {
 }
 
 class ChildActionsNames {
-  static final ActionName<Null> childAction =
-      new ActionName('ChildActions-childAction');
-  static final ActionName<Null> parentAction =
-      new ActionName('ParentActions-parentAction');
-  static final ActionName<Null> grandparentAction =
-      new ActionName('GrandparentActions-grandparentAction');
+  static final childAction = new ActionName<Null>('ChildActions-childAction');
+  static final parentAction =
+      new ActionName<Null>('ParentActions-parentAction');
+  static final grandparentAction =
+      new ActionName<Null>('GrandparentActions-grandparentAction');
 }
 
 class ParentActionsNames {
-  static final ActionName<Null> parentAction =
-      new ActionName('ParentActions-parentAction');
-  static final ActionName<Null> grandparentAction =
-      new ActionName('GrandparentActions-grandparentAction');
+  static final parentAction =
+      new ActionName<Null>('ParentActions-parentAction');
+  static final grandparentAction =
+      new ActionName<Null>('GrandparentActions-grandparentAction');
 }
 
 class GrandparentActionsNames {
-  static final ActionName<Null> grandparentAction =
-      new ActionName('GrandparentActions-grandparentAction');
+  static final grandparentAction =
+      new ActionName<Null>('GrandparentActions-grandparentAction');
 }
 
 // **************************************************************************

--- a/test/unit/inheritance_test_models.g.dart
+++ b/test/unit/inheritance_test_models.g.dart
@@ -13,11 +13,9 @@ class _$ChildActions extends ChildActions {
   factory _$ChildActions() => new _$ChildActions._();
   _$ChildActions._() : super._();
 
-  final ActionDispatcher<Null> childAction =
-      new ActionDispatcher<Null>('ChildActions-childAction');
-  final ActionDispatcher<Null> parentAction =
-      new ActionDispatcher<Null>('ParentActions-parentAction');
-  final ActionDispatcher<Null> grandparentAction =
+  final childAction = new ActionDispatcher<Null>('ChildActions-childAction');
+  final parentAction = new ActionDispatcher<Null>('ParentActions-parentAction');
+  final grandparentAction =
       new ActionDispatcher<Null>('GrandparentActions-grandparentAction');
 
   @override
@@ -30,23 +28,23 @@ class _$ChildActions extends ChildActions {
 
 class ChildActionsNames {
   static final ActionName<Null> childAction =
-      new ActionName<Null>('ChildActions-childAction');
+      new ActionName('ChildActions-childAction');
   static final ActionName<Null> parentAction =
-      new ActionName<Null>('ParentActions-parentAction');
+      new ActionName('ParentActions-parentAction');
   static final ActionName<Null> grandparentAction =
-      new ActionName<Null>('GrandparentActions-grandparentAction');
+      new ActionName('GrandparentActions-grandparentAction');
 }
 
 class ParentActionsNames {
   static final ActionName<Null> parentAction =
-      new ActionName<Null>('ParentActions-parentAction');
+      new ActionName('ParentActions-parentAction');
   static final ActionName<Null> grandparentAction =
-      new ActionName<Null>('GrandparentActions-grandparentAction');
+      new ActionName('GrandparentActions-grandparentAction');
 }
 
 class GrandparentActionsNames {
   static final ActionName<Null> grandparentAction =
-      new ActionName<Null>('GrandparentActions-grandparentAction');
+      new ActionName('GrandparentActions-grandparentAction');
 }
 
 // **************************************************************************

--- a/test/unit/inheritance_test_models.g.dart
+++ b/test/unit/inheritance_test_models.g.dart
@@ -8,6 +8,7 @@ part of inheritance_test_models;
 
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 
 class _$ChildActions extends ChildActions {
   factory _$ChildActions() => new _$ChildActions._();

--- a/test/unit/nested_models.g.dart
+++ b/test/unit/nested_models.g.dart
@@ -13,47 +13,49 @@ class _$BaseActions extends BaseActions {
   factory _$BaseActions() => new _$BaseActions._();
   _$BaseActions._() : super._();
 
-  final ActionDispatcher<Null> baseAction =
-      new ActionDispatcher<Null>('BaseActions-baseAction');
-  final ChildActions child = new ChildActions();
+  final baseAction = new ActionDispatcher<Null>('BaseActions-baseAction');
+
+  final child = new ChildActions();
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
     baseAction.setDispatcher(dispatcher);
+
     child.setDispatcher(dispatcher);
   }
 }
 
 class BaseActionsNames {
   static final ActionName<Null> baseAction =
-      new ActionName<Null>('BaseActions-baseAction');
+      new ActionName('BaseActions-baseAction');
 }
 
 class _$ChildActions extends ChildActions {
   factory _$ChildActions() => new _$ChildActions._();
   _$ChildActions._() : super._();
 
-  final ActionDispatcher<Null> childAction =
-      new ActionDispatcher<Null>('ChildActions-childAction');
-  final GrandchildActions grandchild = new GrandchildActions();
+  final childAction = new ActionDispatcher<Null>('ChildActions-childAction');
+
+  final grandchild = new GrandchildActions();
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
     childAction.setDispatcher(dispatcher);
+
     grandchild.setDispatcher(dispatcher);
   }
 }
 
 class ChildActionsNames {
   static final ActionName<Null> childAction =
-      new ActionName<Null>('ChildActions-childAction');
+      new ActionName('ChildActions-childAction');
 }
 
 class _$GrandchildActions extends GrandchildActions {
   factory _$GrandchildActions() => new _$GrandchildActions._();
   _$GrandchildActions._() : super._();
 
-  final ActionDispatcher<Null> grandchildAction =
+  final grandchildAction =
       new ActionDispatcher<Null>('GrandchildActions-grandchildAction');
 
   @override
@@ -64,7 +66,7 @@ class _$GrandchildActions extends GrandchildActions {
 
 class GrandchildActionsNames {
   static final ActionName<Null> grandchildAction =
-      new ActionName<Null>('GrandchildActions-grandchildAction');
+      new ActionName('GrandchildActions-grandchildAction');
 }
 
 // **************************************************************************

--- a/test/unit/nested_models.g.dart
+++ b/test/unit/nested_models.g.dart
@@ -26,8 +26,7 @@ class _$BaseActions extends BaseActions {
 }
 
 class BaseActionsNames {
-  static final ActionName<Null> baseAction =
-      new ActionName('BaseActions-baseAction');
+  static final baseAction = new ActionName<Null>('BaseActions-baseAction');
 }
 
 class _$ChildActions extends ChildActions {
@@ -47,8 +46,7 @@ class _$ChildActions extends ChildActions {
 }
 
 class ChildActionsNames {
-  static final ActionName<Null> childAction =
-      new ActionName('ChildActions-childAction');
+  static final childAction = new ActionName<Null>('ChildActions-childAction');
 }
 
 class _$GrandchildActions extends GrandchildActions {
@@ -65,8 +63,8 @@ class _$GrandchildActions extends GrandchildActions {
 }
 
 class GrandchildActionsNames {
-  static final ActionName<Null> grandchildAction =
-      new ActionName('GrandchildActions-grandchildAction');
+  static final grandchildAction =
+      new ActionName<Null>('GrandchildActions-grandchildAction');
 }
 
 // **************************************************************************

--- a/test/unit/nested_models.g.dart
+++ b/test/unit/nested_models.g.dart
@@ -8,6 +8,7 @@ part of nested_models;
 
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 
 class _$BaseActions extends BaseActions {
   factory _$BaseActions() => new _$BaseActions._();

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -13,17 +13,18 @@ class _$CounterActions extends CounterActions {
   factory _$CounterActions() => new _$CounterActions._();
   _$CounterActions._() : super._();
 
-  final ActionDispatcher<int> increment =
-      new ActionDispatcher<int>('CounterActions-increment');
-  final ActionDispatcher<int> incrementOther =
+  final increment = new ActionDispatcher<int>('CounterActions-increment');
+  final incrementOther =
       new ActionDispatcher<int>('CounterActions-incrementOther');
-  final SubCounterActions subCounterActions = new SubCounterActions();
-  final MiddlewareActions middlewareActions = new MiddlewareActions();
+
+  final subCounterActions = new SubCounterActions();
+  final middlewareActions = new MiddlewareActions();
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
     increment.setDispatcher(dispatcher);
     incrementOther.setDispatcher(dispatcher);
+
     subCounterActions.setDispatcher(dispatcher);
     middlewareActions.setDispatcher(dispatcher);
   }
@@ -31,19 +32,17 @@ class _$CounterActions extends CounterActions {
 
 class CounterActionsNames {
   static final ActionName<int> increment =
-      new ActionName<int>('CounterActions-increment');
+      new ActionName('CounterActions-increment');
   static final ActionName<int> incrementOther =
-      new ActionName<int>('CounterActions-incrementOther');
+      new ActionName('CounterActions-incrementOther');
 }
 
 class _$SubCounterActions extends SubCounterActions {
   factory _$SubCounterActions() => new _$SubCounterActions._();
   _$SubCounterActions._() : super._();
 
-  final ActionDispatcher<int> increment =
-      new ActionDispatcher<int>('SubCounterActions-increment');
-  final ActionDispatcher<int> doubleIt =
-      new ActionDispatcher<int>('SubCounterActions-doubleIt');
+  final increment = new ActionDispatcher<int>('SubCounterActions-increment');
+  final doubleIt = new ActionDispatcher<int>('SubCounterActions-doubleIt');
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
@@ -54,19 +53,17 @@ class _$SubCounterActions extends SubCounterActions {
 
 class SubCounterActionsNames {
   static final ActionName<int> increment =
-      new ActionName<int>('SubCounterActions-increment');
+      new ActionName('SubCounterActions-increment');
   static final ActionName<int> doubleIt =
-      new ActionName<int>('SubCounterActions-doubleIt');
+      new ActionName('SubCounterActions-doubleIt');
 }
 
 class _$MiddlewareActions extends MiddlewareActions {
   factory _$MiddlewareActions() => new _$MiddlewareActions._();
   _$MiddlewareActions._() : super._();
 
-  final ActionDispatcher<int> doubleIt =
-      new ActionDispatcher<int>('MiddlewareActions-doubleIt');
-  final ActionDispatcher<int> tripleIt =
-      new ActionDispatcher<int>('MiddlewareActions-tripleIt');
+  final doubleIt = new ActionDispatcher<int>('MiddlewareActions-doubleIt');
+  final tripleIt = new ActionDispatcher<int>('MiddlewareActions-tripleIt');
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
@@ -77,9 +74,9 @@ class _$MiddlewareActions extends MiddlewareActions {
 
 class MiddlewareActionsNames {
   static final ActionName<int> doubleIt =
-      new ActionName<int>('MiddlewareActions-doubleIt');
+      new ActionName('MiddlewareActions-doubleIt');
   static final ActionName<int> tripleIt =
-      new ActionName<int>('MiddlewareActions-tripleIt');
+      new ActionName('MiddlewareActions-tripleIt');
 }
 
 // **************************************************************************

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -31,10 +31,9 @@ class _$CounterActions extends CounterActions {
 }
 
 class CounterActionsNames {
-  static final ActionName<int> increment =
-      new ActionName('CounterActions-increment');
-  static final ActionName<int> incrementOther =
-      new ActionName('CounterActions-incrementOther');
+  static final increment = new ActionName<int>('CounterActions-increment');
+  static final incrementOther =
+      new ActionName<int>('CounterActions-incrementOther');
 }
 
 class _$SubCounterActions extends SubCounterActions {
@@ -52,10 +51,8 @@ class _$SubCounterActions extends SubCounterActions {
 }
 
 class SubCounterActionsNames {
-  static final ActionName<int> increment =
-      new ActionName('SubCounterActions-increment');
-  static final ActionName<int> doubleIt =
-      new ActionName('SubCounterActions-doubleIt');
+  static final increment = new ActionName<int>('SubCounterActions-increment');
+  static final doubleIt = new ActionName<int>('SubCounterActions-doubleIt');
 }
 
 class _$MiddlewareActions extends MiddlewareActions {
@@ -73,10 +70,8 @@ class _$MiddlewareActions extends MiddlewareActions {
 }
 
 class MiddlewareActionsNames {
-  static final ActionName<int> doubleIt =
-      new ActionName('MiddlewareActions-doubleIt');
-  static final ActionName<int> tripleIt =
-      new ActionName('MiddlewareActions-tripleIt');
+  static final doubleIt = new ActionName<int>('MiddlewareActions-doubleIt');
+  static final tripleIt = new ActionName<int>('MiddlewareActions-tripleIt');
 }
 
 // **************************************************************************

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -8,6 +8,7 @@ part of test_counter;
 
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
+// ignore_for_file: overridden_fields
 
 class _$CounterActions extends CounterActions {
   factory _$CounterActions() => new _$CounterActions._();


### PR DESCRIPTION
* rework generator to lift analyzer version constraint.
* open analyzer range
* generator now uses source parsing to resolve action generic types which allows any unresolved type to be used as an action payload.
* generated actions classes now use type inference.
* bump built_value lower bound to 6.1.4 since it is impossible for pub to resolve to anything lower due to the build dependency constraint.
