### PR TITLE
Ignore lint rule in generated output

### DIFF
--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -9,6 +9,7 @@ part of example;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$CounterActions extends CounterActions {
   factory _$CounterActions() => new _$CounterActions._();

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -27,6 +27,7 @@ const _lintIgnores = """
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 """;
 
 ActionsClass _actionsClassFromElement(ClassElement element) => new ActionsClass(

--- a/test/unit/action_generics_models.g.dart
+++ b/test/unit/action_generics_models.g.dart
@@ -9,6 +9,7 @@ part of action_generics_models;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$ActionGenericsActions extends ActionGenericsActions {
   factory _$ActionGenericsActions() => new _$ActionGenericsActions._();

--- a/test/unit/collection_models.g.dart
+++ b/test/unit/collection_models.g.dart
@@ -9,6 +9,7 @@ part of collection_models;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$CollectionActions extends CollectionActions {
   factory _$CollectionActions() => new _$CollectionActions._();

--- a/test/unit/inheritance_test_models.g.dart
+++ b/test/unit/inheritance_test_models.g.dart
@@ -9,6 +9,7 @@ part of inheritance_test_models;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$ChildActions extends ChildActions {
   factory _$ChildActions() => new _$ChildActions._();

--- a/test/unit/nested_models.g.dart
+++ b/test/unit/nested_models.g.dart
@@ -9,6 +9,7 @@ part of nested_models;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$BaseActions extends BaseActions {
   factory _$BaseActions() => new _$BaseActions._();

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -9,6 +9,7 @@ part of test_counter;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$CounterActions extends CounterActions {
   factory _$CounterActions() => new _$CounterActions._();


### PR DESCRIPTION
#### Problem:
- Consumers using the lint `type_annotate_public_apis` fail analysis when using the latest release

#### Fix:
- Add `ignore_for_file: type_annotate_public_apis` to the lint ignores