### PR TITLE
Fix #125: Actions can be handled by multiple reducers/middlewares

### DIFF
--- a/test/unit/middleware_test.dart
+++ b/test/unit/middleware_test.dart
@@ -33,7 +33,7 @@ void main() {
     test('1 middleware doubles count and updates state', () async {
       setup();
       expect(store.state.count, 1);
-      store.actions.middlewareActions.doubleIt(0);
+      store.actions.middlewareActions.doubleIt();
       expect(store.state.count, 3);
     });
 
@@ -52,7 +52,7 @@ void main() {
       });
 
       // should add double the current state twice
-      store.actions.middlewareActions.doubleIt(0);
+      store.actions.middlewareActions.doubleIt();
       var stateChange = await onStateChangeCompleter.future;
       expect(stateChange.prev.count, 1);
       expect(stateChange.next.count, 3);
@@ -64,14 +64,21 @@ void main() {
     test('combine works with tripleIt', () async {
       setup();
       expect(store.state.count, 1);
-      store.actions.middlewareActions.tripleIt(0);
+      store.actions.middlewareActions.tripleIt();
       expect(store.state.count, 4);
+    });
+
+    test('adding multiple middleware for the same action works', () async {
+      setup();
+      expect(store.state.count, 1);
+      store.actions.middlewareActions.timesSix();
+      expect(store.state.count, 6);
     });
 
     test('combineNested works with SubCounter doubleIt', () async {
       setup();
       expect(store.state.subCounter.subCount, 1);
-      store.actions.subCounterActions.doubleIt(0);
+      store.actions.subCounterActions.doubleIt();
       expect(store.state.subCounter.subCount, 3);
     });
   });

--- a/test/unit/reducer_test.dart
+++ b/test/unit/reducer_test.dart
@@ -1,0 +1,28 @@
+import 'package:built_redux/built_redux.dart';
+import 'package:test/test.dart';
+
+import 'test_counter.dart';
+
+void main() {
+  group('reducer', () {
+    Store<Counter, CounterBuilder, CounterActions> store;
+
+    setUp(() {
+      var actions = CounterActions();
+      var defaultValue = Counter();
+
+      store = Store<Counter, CounterBuilder, CounterActions>(
+          reducer, defaultValue, actions);
+    });
+
+    tearDown(() {
+      store.dispose();
+    });
+
+    test('multiple reducer for the same action', () {
+      expect(store.state.count, 1);
+      store.actions.doubleIncrement(2);
+      expect(store.state.count, 5);
+    });
+  });
+}

--- a/test/unit/test_counter.g.dart
+++ b/test/unit/test_counter.g.dart
@@ -16,6 +16,8 @@ class _$CounterActions extends CounterActions {
   _$CounterActions._() : super._();
 
   final increment = ActionDispatcher<int>('CounterActions-increment');
+  final doubleIncrement =
+      ActionDispatcher<int>('CounterActions-doubleIncrement');
   final incrementOther = ActionDispatcher<int>('CounterActions-incrementOther');
 
   final subCounterActions = SubCounterActions();
@@ -24,6 +26,7 @@ class _$CounterActions extends CounterActions {
   @override
   void setDispatcher(Dispatcher dispatcher) {
     increment.setDispatcher(dispatcher);
+    doubleIncrement.setDispatcher(dispatcher);
     incrementOther.setDispatcher(dispatcher);
 
     subCounterActions.setDispatcher(dispatcher);
@@ -33,6 +36,8 @@ class _$CounterActions extends CounterActions {
 
 class CounterActionsNames {
   static final increment = ActionName<int>('CounterActions-increment');
+  static final doubleIncrement =
+      ActionName<int>('CounterActions-doubleIncrement');
   static final incrementOther =
       ActionName<int>('CounterActions-incrementOther');
 }
@@ -60,19 +65,22 @@ class _$MiddlewareActions extends MiddlewareActions {
   factory _$MiddlewareActions() => _$MiddlewareActions._();
   _$MiddlewareActions._() : super._();
 
-  final doubleIt = ActionDispatcher<int>('MiddlewareActions-doubleIt');
-  final tripleIt = ActionDispatcher<int>('MiddlewareActions-tripleIt');
+  final doubleIt = ActionDispatcher<void>('MiddlewareActions-doubleIt');
+  final tripleIt = ActionDispatcher<void>('MiddlewareActions-tripleIt');
+  final timesSix = ActionDispatcher<void>('MiddlewareActions-timesSix');
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
     doubleIt.setDispatcher(dispatcher);
     tripleIt.setDispatcher(dispatcher);
+    timesSix.setDispatcher(dispatcher);
   }
 }
 
 class MiddlewareActionsNames {
-  static final doubleIt = ActionName<int>('MiddlewareActions-doubleIt');
-  static final tripleIt = ActionName<int>('MiddlewareActions-tripleIt');
+  static final doubleIt = ActionName<void>('MiddlewareActions-doubleIt');
+  static final tripleIt = ActionName<void>('MiddlewareActions-tripleIt');
+  static final timesSix = ActionName<void>('MiddlewareActions-timesSix');
 }
 
 // **************************************************************************


### PR DESCRIPTION
When multiple middlewares/reducers for the same action are registered, all of them will be called.
I also added a few tests.