### PR TITLE
Widen analyzer / built_value ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.5.12
-* tighten analyzer to require ^0.39.0
+* update analyzer to dependency range 
 * fix analyzer deprecations
 
 ## 7.5.11

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,17 +4,17 @@ description:
   A state management library written in dart that enforces immutability
 homepage: https://github.com/davidmarne/built_redux
 dependencies:
-  analyzer: '>=0.39.3 <0.40.0'
+  analyzer: '>=0.39.3 <0.42.0'
   build: ^1.2.2
-  built_collection: ^4.3.0
-  built_value: '>=7.0.8 <8.0.0'
+  built_collection: ">=4.3.0 <6.0.0"
+  built_value: '>=7.0.8 <9.0.0'
   source_gen: ^0.9.4+6
   test: ^1.9.1
 
 dev_dependencies:
   build_runner: ^1.7.1
   build_test: ^0.10.11
-  built_value_generator: ^7.0.0
+  built_value_generator: ">=7.0.0 <9.0.0"
   build_web_compilers: ^2.7.1
   workiva_analysis_options: ^1.0.0
 


### PR DESCRIPTION
In order to get passing dev CI builds using the Dart SDK 2.12.x versions, we need to unlock `analyzer` 0.40 or higher.

@davidmarne @davidmarne-wf I was thinking maybe we could merge this into/include this in [the 7.5.12 release](https://github.com/davidmarne/built_redux/pull/151)?