### PR TITLE
Continue CI on errors

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -12,7 +12,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         sdk: [ 2.18.7, stable, beta ]
     steps:


### PR DESCRIPTION
The testing matrix includes dev and stable, both of which experienced a failure. We'd like the other versions to not be cancelled if one fails.

This updates the GHA config to continue running if something else fails.
GHA failure docs https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures